### PR TITLE
feat: Add map visibility toggle with responsive layout

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -41,7 +41,7 @@ export default function Home() {
   const [error, setError] = useState<string | null>(null);
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [selectedDayIndex, _setSelectedDayIndex] = useState<number | null>(null);
-  const [showMap, setShowMap] = useState(true);
+  const [showMap, setShowMap] = useState(false);
   const [activeTab, setActiveTab] = useState<'chat' | 'itinerary' | 'map'>('chat');
 
   // Close user menu when clicking outside
@@ -324,6 +324,23 @@ export default function Home() {
                 </svg>
                 {isEditMode ? 'View Mode' : 'Edit Mode'}
               </button>
+              <button
+                onClick={() => {
+                  setShowMap(!showMap);
+                  if (!showMap) setActiveTab('map');
+                }}
+                className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded transition-colors ${
+                  showMap
+                    ? 'bg-blue-100 text-blue-700 hover:bg-blue-200'
+                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                }`}
+                title={showMap ? 'Hide Map' : 'Show Map'}
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
+                </svg>
+                {showMap ? 'Hide Map' : 'Show Map'}
+              </button>
             </div>
           )}
           <button
@@ -461,11 +478,13 @@ export default function Home() {
         {/* Chat Area */}
         <div className={`${
           trip
-            ? 'lg:w-1/3 lg:block' // Desktop: always visible, 1/3 width
+            ? showMap
+              ? 'lg:w-1/3' // Desktop with map: 1/3 width
+              : 'lg:w-1/2' // Desktop without map: 1/2 width
             : 'w-full' // No trip: full width
         } ${
           trip && activeTab !== 'chat' ? 'hidden' : '' // Mobile: hide when other tabs active
-        } border-r border-gray-200`}>
+        } border-r border-gray-200 transition-all duration-300 ease-in-out lg:block`}>
           <Chat
             messages={messages}
             onSendMessage={handleSendMessage}
@@ -479,9 +498,13 @@ export default function Home() {
 
         {/* Itinerary View */}
         {trip && (
-          <div className={`lg:w-1/3 lg:block ${
+          <div className={`${
+            showMap
+              ? 'lg:w-1/3' // Desktop with map: 1/3 width
+              : 'lg:w-1/2' // Desktop without map: 1/2 width
+          } ${
             activeTab !== 'itinerary' ? 'hidden' : 'w-full'
-          } bg-white border-r border-gray-200`}>
+          } bg-white border-r border-gray-200 transition-all duration-300 ease-in-out lg:block`}>
             <ItineraryView
               trip={trip}
               isEditMode={isEditMode}
@@ -497,39 +520,15 @@ export default function Home() {
 
         {/* Map View */}
         {trip && showMap && (
-          <div className={`lg:w-1/3 lg:block ${
+          <div className={`lg:w-1/3 ${
             activeTab !== 'map' ? 'hidden' : 'w-full'
-          } bg-gray-100 relative`}>
-            <button
-              onClick={() => setShowMap(false)}
-              className="absolute top-4 right-4 z-10 bg-white rounded-lg shadow-lg p-2 hover:bg-gray-50 transition-colors"
-              title="Hide map"
-            >
-              <svg className="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
+          } bg-gray-100 transition-all duration-300 ease-in-out lg:block`}>
             <MapView
               trip={trip}
               selectedDayIndex={selectedDayIndex}
+              isVisible={showMap}
             />
           </div>
-        )}
-
-        {/* Show Map Button (when hidden, desktop only) */}
-        {trip && !showMap && (
-          <button
-            onClick={() => {
-              setShowMap(true);
-              setActiveTab('map');
-            }}
-            className="hidden lg:block fixed bottom-8 right-8 bg-blue-600 text-white rounded-full p-4 shadow-lg hover:bg-blue-700 transition-colors z-20"
-            title="Show map"
-          >
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
-            </svg>
-          </button>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Adds a "Show Map" / "Hide Map" toggle button in the header, allowing users to control map visibility. The map starts hidden by default when a trip is created, and the layout dynamically adjusts to provide more space when the map is hidden.

## Changes

- **Toggle button in header**: Located next to Edit Mode button with visual state indicator (blue highlight when map is shown)
- **Default behavior**: Map starts hidden when trip is created
- **Responsive layout**: 
  - Map visible: Chat, Itinerary, Map each take 1/3 width
  - Map hidden: Chat and Itinerary expand to 1/2 width each
- **Smooth transitions**: 300ms ease-in-out animation when toggling
- **Bug fix**: Auto-resize map after transition to prevent rendering glitches
- **Mobile support**: Map accessible via tab navigation

## Technical Implementation

- Added `showMap` state (default: `false`) in Home component
- Conditional width classes based on map visibility
- MapView receives `isVisible` prop to trigger resize after CSS transition completes
- Removed previous floating map button and close button UI elements

## Test Plan

- [ ] Create a new trip and verify map is hidden by default
- [ ] Click "Show Map" button and verify map appears with smooth animation
- [ ] Verify Chat and Itinerary panels resize from 50% to 33% width
- [ ] Click "Hide Map" and verify panels expand back to 50% width
- [ ] Verify map renders correctly without visual glitches
- [ ] Test on mobile: verify map tab shows/hides correctly
- [ ] Verify button highlights blue when map is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)