### PR TITLE
fix: Persist suggestion card added state across page refreshes

### DIFF
--- a/src/components/SuggestionCard.tsx
+++ b/src/components/SuggestionCard.tsx
@@ -20,8 +20,10 @@ export function SuggestionCard({
   );
   const [expandedImage, setExpandedImage] = useState<string | null>(null);
   const [photos, setPhotos] = useState<Photo[]>([]);
-  const [isAdded, setIsAdded] = useState(false);
-  const [addedToDayIndex, setAddedToDayIndex] = useState<number | null>(null);
+
+  // Use persisted flags from suggestion prop
+  const isAdded = suggestion.isAdded ?? false;
+  const addedToDayIndex = suggestion.addedToDayIndex ?? null;
 
   // Fetch photos if photoQuery is provided
   useEffect(() => {
@@ -176,11 +178,7 @@ export function SuggestionCard({
                 ))}
               </select>
               <button
-                onClick={() => {
-                  setIsAdded(true);
-                  setAddedToDayIndex(selectedDayIndex);
-                  onAddToDay(selectedDayIndex);
-                }}
+                onClick={() => onAddToDay(selectedDayIndex)}
                 className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors font-medium"
               >
                 Add to Day

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -21,6 +21,7 @@ export default function Home() {
     hasUnsavedChanges,
     setTrip,
     addMessage,
+    markSuggestionAdded,
     setConversationState,
     setIsLoading,
     addItemToDay,
@@ -202,6 +203,9 @@ export default function Home() {
     };
 
     addItemToDay(dayIndex, item);
+
+    // Mark suggestion as added in the store
+    markSuggestionAdded(suggestionId, dayIndex);
 
     // Add confirmation message
     const confirmMsg = {

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -39,6 +39,7 @@ interface StoreState {
   // Trip actions
   setTrip: (trip: Trip | null) => void;
   addMessage: (message: ChatMessage) => void;
+  markSuggestionAdded: (suggestionId: string, dayIndex: number) => void;
   setConversationState: (state: ConversationState) => void;
   setIsLoading: (loading: boolean) => void;
   addItemToDay: (dayIndex: number, item: ItineraryItem) => void;
@@ -131,6 +132,22 @@ export const useStore = create<StoreState>()(
 
       addMessage: (message) =>
         set((state) => ({ messages: [...state.messages, message] })),
+
+      markSuggestionAdded: (suggestionId, dayIndex) =>
+        set((state) => ({
+          messages: state.messages.map((msg) =>
+            msg.suggestionCard?.id === suggestionId
+              ? {
+                  ...msg,
+                  suggestionCard: {
+                    ...msg.suggestionCard,
+                    isAdded: true,
+                    addedToDayIndex: dayIndex,
+                  },
+                }
+              : msg
+          ),
+        })),
 
       setConversationState: (conversationState) => set({ conversationState }),
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -87,6 +87,8 @@ export interface SuggestionCard {
   itemType: ItemType;
   duration?: string;
   photoQuery?: string; // LLM-generated photo search query (Milestone 3.3)
+  isAdded?: boolean; // Track if this suggestion has been added to itinerary
+  addedToDayIndex?: number; // Which day it was added to
 }
 
 export interface QuickReply {


### PR DESCRIPTION
## Summary

This PR fixes an issue where the "Activity added" confirmation message in suggestion cards would disappear after a page refresh. The state is now properly persisted in both localStorage (via Zustand) and the database.

## Problem

After merging PR #13, users reported that when they:
1. Click "Add to Day" on a suggestion card → ✅ Shows confirmation message
2. Refresh the page → ❌ Confirmation disappears and buttons reappear
3. Could accidentally add the same suggestion again

The issue was that the `isAdded` state was stored locally in the component and got reset on refresh.

## Solution

**Added persistence to SuggestionCard state:**

1. **Updated SuggestionCard type** (`src/types/index.ts`)
   - Added `isAdded?: boolean` field to track if suggestion was added
   - Added `addedToDayIndex?: number` to remember which day it was added to

2. **Created store action** (`src/store/useStore.ts`)
   - Added `markSuggestionAdded(suggestionId, dayIndex)` action
   - Updates the suggestion card in messages array with persisted flags
   - State automatically syncs to localStorage via Zustand persist middleware
   - State auto-saves to database via existing auto-save mechanism

3. **Updated Home.tsx** (`src/pages/Home.tsx`)
   - Call `markSuggestionAdded()` when adding a suggestion to itinerary
   - Ensures state is persisted before showing confirmation

4. **Refactored SuggestionCard** (`src/components/SuggestionCard.tsx`)
   - Removed local state for `isAdded` and `addedToDayIndex`
   - Now uses persisted values from `suggestion` prop
   - Confirmation message persists across page refreshes

## Test Plan

- [x] Add a suggestion to itinerary
- [x] Verify confirmation message appears
- [x] Refresh the page
- [x] Verify confirmation message still shows (not reset)
- [x] Verify cannot add the same suggestion again
- [x] Verify state persists in localStorage
- [x] Verify state persists in database after auto-save

## Before

- ❌ Confirmation message disappeared after refresh
- ❌ User could accidentally add same suggestion multiple times after refresh

## After  

- ✅ Confirmation message persists across refreshes
- ✅ State saved to localStorage and database
- ✅ Cannot add same suggestion twice, even after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)