### PR TITLE
feat: add places count to trip statistics

### DIFF
--- a/server/routes/trips.ts
+++ b/server/routes/trips.ts
@@ -170,6 +170,17 @@ router.get('/stats', requireAuth, async (req: Request, res: Response) => {
         archived: 0, // Exclude archived from this view
       },
       destinationsCount: new Set(trips.map(t => t.destination)).size,
+      placesCount: new Set(
+        trips.flatMap(trip => {
+          const tripData = trip.dataJson as any;
+          if (tripData && tripData.days && Array.isArray(tripData.days)) {
+            return tripData.days
+              .map((day: any) => day.location)
+              .filter((location: any) => location); // Filter out null/undefined locations
+          }
+          return [];
+        })
+      ).size,
       totalDays: trips.reduce((sum, trip) => {
         if (trip.startDate && trip.endDate) {
           const days = Math.ceil(

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -554,6 +554,12 @@ export function Dashboard() {
                     <p className="text-2xl font-bold text-purple-900">{stats.totalDays}</p>
                   </div>
                 )}
+                {stats.placesCount > 0 && (
+                  <div className="bg-teal-50 rounded-lg p-4">
+                    <p className="text-sm text-teal-600 font-medium">Places</p>
+                    <p className="text-2xl font-bold text-teal-900">{stats.placesCount}</p>
+                  </div>
+                )}
                 {stats.activitiesCount > 0 && (
                   <div className="bg-orange-50 rounded-lg p-4">
                     <p className="text-sm text-orange-600 font-medium">Activities</p>

--- a/src/services/tripApi.ts
+++ b/src/services/tripApi.ts
@@ -254,6 +254,7 @@ export interface TripStats {
     archived: number;
   };
   destinationsCount: number;
+  placesCount: number;
   totalDays: number;
   activitiesCount: number;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -150,6 +150,7 @@ export interface TripStats {
   total: number;
   byStatus: Record<TripStatus, number>;
   destinationsCount: number;
+  placesCount: number;
   totalDays: number;
   activitiesCount: number;
 }


### PR DESCRIPTION
## Summary
Add a new "Places" metric to the dashboard statistics that counts unique cities/locations visited across all trips.

This enhancement provides users with better visibility into the variety of places they've visited, complementing the existing destinations count metric.

## Changes
- ✨ Add `placesCount` field to TripStats interface in both frontend types and backend API
- 🔧 Implement places count calculation in backend `/api/trips/stats` endpoint
  - Extracts unique locations from `day.location` fields across all trips
  - Uses Set to ensure uniqueness and filters out null/undefined values
- 🎨 Add Places stat card to Dashboard UI with teal color scheme
- 📊 Position between Total Days and Activities stats for logical flow

## Example
If you have trips visiting:
- Peru: Lima, Cusco, Arequipa (3 places)
- Japan: Tokyo, Kyoto (2 places)

Dashboard will show: **3 destinations** • **5 places**

## Test plan
- [x] Verify places count displays correctly on Dashboard
- [x] Confirm unique counting works across multiple trips
- [x] Check that null/undefined locations are filtered out
- [x] Validate teal color scheme matches design

🤖 Generated with [Claude Code](https://claude.com/claude-code)