### PR TITLE
feat: improve geocoding accuracy and mobile map UX

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -552,7 +552,7 @@ export default function Home() {
                 setShowMap(!showMap);
                 if (!showMap) setActiveTab('map');
               }}
-              className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded transition-colors ${
+              className={`hidden lg:flex items-center gap-1.5 px-3 py-1.5 text-sm rounded transition-colors ${
                 showMap
                   ? 'bg-blue-100 text-blue-700 hover:bg-blue-200'
                   : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
@@ -704,14 +704,14 @@ export default function Home() {
         )}
 
         {/* Map View */}
-        {trip && showMap && (
+        {trip && (showMap || activeTab === 'map') && (
           <div className={`lg:w-1/3 ${
             activeTab !== 'map' ? 'hidden' : 'w-full'
           } bg-gray-100 transition-all duration-300 ease-in-out lg:block`}>
             <MapView
               trip={trip}
               selectedDayIndex={selectedDayIndex}
-              isVisible={showMap}
+              isVisible={showMap || activeTab === 'map'}
             />
           </div>
         )}

--- a/src/services/mapApi.ts
+++ b/src/services/mapApi.ts
@@ -25,14 +25,61 @@ interface DirectionsResponse {
   error?: string;
 }
 
+// Map common country names to ISO 3166-1 alpha-2 codes
+const COUNTRY_CODE_MAP: Record<string, string> = {
+  'china': 'cn',
+  'united states': 'us',
+  'usa': 'us',
+  'japan': 'jp',
+  'south korea': 'kr',
+  'france': 'fr',
+  'italy': 'it',
+  'spain': 'es',
+  'germany': 'de',
+  'united kingdom': 'gb',
+  'uk': 'gb',
+  'canada': 'ca',
+  'australia': 'au',
+  'mexico': 'mx',
+  'brazil': 'br',
+  'india': 'in',
+  'thailand': 'th',
+  'vietnam': 'vn',
+  'singapore': 'sg',
+  'malaysia': 'my',
+  'indonesia': 'id',
+  'philippines': 'ph',
+  'new zealand': 'nz',
+  'switzerland': 'ch',
+  'netherlands': 'nl',
+  'portugal': 'pt',
+  'greece': 'gr',
+  'turkey': 'tr',
+  'egypt': 'eg',
+  'south africa': 'za',
+  'argentina': 'ar',
+  'chile': 'cl',
+  'peru': 'pe',
+  'colombia': 'co',
+};
+
+/**
+ * Get ISO country code from country name
+ */
+function getCountryCode(country: string): string | undefined {
+  return COUNTRY_CODE_MAP[country.toLowerCase()];
+}
+
 /**
  * Geocode a location query to coordinates
  * @param query - Location name or address
  * @param proximity - Optional proximity bias for results
+ * @param country - Optional country name to restrict results
  */
 export async function geocodeLocation(
   query: string,
-  proximity?: { lng: number; lat: number }
+  proximity?: { lng: number; lat: number },
+  country?: string
 ): Promise<GeocodeResult> {
   const params = new URLSearchParams({
     query,
@@ -40,6 +87,13 @@ export async function geocodeLocation(
 
   if (proximity) {
     params.append('proximity', JSON.stringify(proximity));
+  }
+
+  if (country) {
+    const countryCode = getCountryCode(country);
+    if (countryCode) {
+      params.append('country', countryCode);
+    }
   }
 
   const response = await fetch(`${API_URL}/api/map/geocode?${params.toString()}`);


### PR DESCRIPTION
## Summary

This PR addresses two issues:

### 1. Geocoding Accuracy Improvements

**Problem**: Location names were being geocoded to incorrect countries. For example, "Visit West Lake" was geocoded to West Lake, Texas instead of West Lake in Hangzhou, China.

**Solution**: Implemented a multi-layered geocoding strategy:
- Added **country restriction** parameter to Mapbox geocoding API (ISO 3166-1 alpha-2 codes)
- Implemented **day-specific proximity bias** by geocoding each day's location first
- Changed geocoding context from trip `destination` to `day.location` for better accuracy
- Created `COUNTRY_CODE_MAP` with 30+ countries for easy country code lookups

**Technical Changes**:
- `server/routes/map.ts`: Add country parameter to geocode endpoint schema and Mapbox API call
- `src/services/mapApi.ts`: Add COUNTRY_CODE_MAP and update geocodeLocation() signature
- `src/services/conversationEngine.ts`: Use day-specific context and proximity bias for all geocoding

**Example**: Now "Visit West Lake" with day.location="Hangzhou" and destination="China" will:
1. Geocode "Hangzhou, China" to get day proximity bias
2. Geocode "Visit West Lake, Hangzhou" with proximity to Hangzhou
3. Apply country restriction (cn) to filter out US results
4. Return West Lake in Hangzhou, China ✅

### 2. Mobile Map Visibility

**Problem**: On mobile, the "Show Map" button cluttered the UI, and the map wasn't automatically shown when the Map tab was selected.

**Solution**: 
- Hide "Show Map" button on mobile (show only on desktop lg+ screens)
- Auto-show map when Map tab is selected on mobile
- Preserve desktop behavior where button toggles map visibility

**Technical Changes**:
- `src/pages/Home.tsx`: 
  - Added `hidden lg:flex` to "Show Map" button (line 555)
  - Updated map visibility condition to `showMap || activeTab === 'map'` (line 707, 714)

## Test Plan

- [x] Build passes (npm run build)
- [ ] Test geocoding accuracy: Create trip to China with activities in Hangzhou
- [ ] Verify "Visit West Lake" geocodes to Hangzhou, not Texas
- [ ] Test mobile map: Resize browser to mobile width
- [ ] Verify "Show Map" button is hidden on mobile
- [ ] Verify map appears when Map tab is selected
- [ ] Test desktop: Verify "Show Map" button works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)