### PR TITLE
fix: persist custom trip titles and refresh dashboard

### DIFF
--- a/src/components/TripHeader.tsx
+++ b/src/components/TripHeader.tsx
@@ -70,7 +70,7 @@ export function TripHeader({
       <div className="px-6 pt-4 pb-2">
         <nav className="flex items-center gap-2 text-sm text-gray-600">
           <button
-            onClick={() => navigate('/dashboard')}
+            onClick={() => navigate('/dashboard', { state: { from: 'trip' } })}
             className="hover:text-gray-900 transition-colors"
           >
             Dashboard

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { TripCard } from '../components/TripCard';
 import { SkeletonTripCard } from '../components/SkeletonTripCard';
 import { TripsFilterBar } from '../components/TripsFilterBar';
@@ -19,6 +19,7 @@ import toast, { Toaster } from 'react-hot-toast';
 
 export function Dashboard() {
   const navigate = useNavigate();
+  const location = useLocation();
   const clearAll = useStore((state) => state.clearAll);
   const user = useStore((state) => state.user);
   const logout = useStore((state) => state.logout);
@@ -79,6 +80,14 @@ export function Dashboard() {
   React.useEffect(() => {
     loadData();
   }, [loadData]);
+
+  // Reload trips when navigating back to dashboard
+  React.useEffect(() => {
+    if (location.state?.from) {
+      // User navigated back from another page, refresh the data
+      loadData();
+    }
+  }, [location.key, loadData]);
 
   // Auto-redirect new users with no trips to create their first trip (but not admins)
   React.useEffect(() => {

--- a/src/services/tripApi.ts
+++ b/src/services/tripApi.ts
@@ -52,7 +52,7 @@ export async function createTrip(
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include', // Include auth cookies
     body: JSON.stringify({
-      title: `${trip.destination} Trip`, // Generate a title
+      title: trip.title || `${trip.destination} Trip`, // Use custom title or generate one
       destination: trip.destination,
       startDate: trip.startDate,
       endDate: trip.endDate,
@@ -83,7 +83,7 @@ export async function updateTrip(
     credentials: 'include', // Include auth cookies
     body: JSON.stringify({
       ...(tripData && {
-        title: `${tripData.destination} Trip`,
+        title: tripData.title || `${tripData.destination} Trip`,
         destination: tripData.destination,
         startDate: tripData.startDate,
         endDate: tripData.endDate,


### PR DESCRIPTION
## Summary

Fixed two related issues:
1. Custom trip titles were being overwritten with default "{destination} Trip" format when saving to database
2. Dashboard was not refreshing to show updated trip names after editing them in the trip page

## Problem

When users edited a trip title in the TripHeader component, the custom title would be saved to the local store but then overwritten with the auto-generated title format when syncing to the database. Additionally, when navigating back to the dashboard, the old title would still be displayed even after a page refresh.

## Solution

**Title Persistence (tripApi.ts)**
- Modified `createTrip()` to use `trip.title` if set, falling back to generated format
- Modified `updateTrip()` to use `tripData.title` if set, falling back to generated format

**Dashboard Refresh (Dashboard.tsx + TripHeader.tsx)**
- Added location-based reload logic in Dashboard that detects navigation from trip page
- Updated TripHeader to pass navigation state when clicking "Dashboard" breadcrumb link

## Changes

- `src/services/tripApi.ts`: Use trip.title if set in createTrip and updateTrip
- `src/pages/Dashboard.tsx`: Reload trips when navigating back with location state
- `src/components/TripHeader.tsx`: Pass navigation state to dashboard link

## Testing

- Edit a trip title in the trip page
- Click "Dashboard" in breadcrumb
- Verify the dashboard shows the updated custom title
- Refresh the page and verify the title persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)