### PR TITLE
feat: Multi-platform content integration with extensible architecture

### DIFF
--- a/prisma/migrations/20251007163953_add_unified_social_content_cache/migration.sql
+++ b/prisma/migrations/20251007163953_add_unified_social_content_cache/migration.sql
@@ -1,0 +1,52 @@
+-- CreateTable
+CREATE TABLE "social_content_cache" (
+    "id" TEXT NOT NULL,
+    "platform" TEXT NOT NULL,
+    "platform_post_id" TEXT NOT NULL,
+    "query" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "content_lang" TEXT NOT NULL DEFAULT 'en',
+    "summary" TEXT NOT NULL,
+    "images" TEXT[],
+    "video_url" TEXT,
+    "tags" TEXT[],
+    "author_name" TEXT NOT NULL,
+    "author_id" TEXT NOT NULL,
+    "author_avatar" TEXT,
+    "engagement_score" INTEGER NOT NULL DEFAULT 0,
+    "likes" INTEGER NOT NULL DEFAULT 0,
+    "comments" INTEGER NOT NULL DEFAULT 0,
+    "shares" INTEGER NOT NULL DEFAULT 0,
+    "post_url" TEXT NOT NULL,
+    "location" TEXT,
+    "published_at" TIMESTAMP(3),
+    "platform_meta" JSONB,
+    "usage_count" INTEGER NOT NULL DEFAULT 0,
+    "quality_score" DOUBLE PRECISION,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "social_content_cache_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "social_content_cache_platform_idx" ON "social_content_cache"("platform");
+
+-- CreateIndex
+CREATE INDEX "social_content_cache_query_idx" ON "social_content_cache"("query");
+
+-- CreateIndex
+CREATE INDEX "social_content_cache_location_idx" ON "social_content_cache"("location");
+
+-- CreateIndex
+CREATE INDEX "social_content_cache_engagement_score_idx" ON "social_content_cache"("engagement_score");
+
+-- CreateIndex
+CREATE INDEX "social_content_cache_usage_count_idx" ON "social_content_cache"("usage_count");
+
+-- CreateIndex
+CREATE INDEX "social_content_cache_content_lang_idx" ON "social_content_cache"("content_lang");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "social_content_cache_platform_platform_post_id_key" ON "social_content_cache"("platform", "platform_post_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -326,7 +326,8 @@ model ParsedBooking {
   @@map("parsed_bookings")
 }
 
-// XiaohongshuCache table - caches Xiaohongshu notes for travel inspiration
+// XiaohongshuCache table - DEPRECATED: Use SocialContentCache instead
+// Kept for backward compatibility and migration
 model XiaohongshuCache {
   id                String   @id @default(cuid())
   noteId            String   @unique @map("note_id") // Original Xiaohongshu note ID
@@ -364,4 +365,60 @@ model XiaohongshuCache {
   @@index([usageCount]) // Track popular notes
   @@index([createdAt]) // Order by recency
   @@map("xiaohongshu_cache")
+}
+
+// SocialContentCache table - Unified cache for all social platforms (Xiaohongshu, Reddit, TikTok, etc.)
+model SocialContentCache {
+  id                String   @id @default(cuid())
+
+  // Platform identification
+  platform          String                 // 'xiaohongshu' | 'reddit' | 'tiktok' | 'instagram' | etc.
+  platformPostId    String   @map("platform_post_id") // Original post ID from platform
+
+  // Core content (language-agnostic)
+  query             String                 // Search term
+  title             String
+  content           String   @db.Text      // Original content
+  contentLang       String   @default("en") @map("content_lang") // 'zh' | 'en' | 'ja' | etc.
+  summary           String   @db.Text      // LLM-generated English summary
+
+  // Media
+  images            String[]
+  videoUrl          String?  @map("video_url")
+  tags              String[]
+
+  // Author
+  authorName        String   @map("author_name")
+  authorId          String   @map("author_id")
+  authorAvatar      String?  @map("author_avatar")
+
+  // Engagement (normalized across platforms)
+  engagementScore   Int      @default(0) @map("engagement_score") // Normalized score (0-1000)
+  likes             Int      @default(0)  // Or upvotes
+  comments          Int      @default(0)
+  shares            Int      @default(0)  // Or awards on Reddit
+
+  // Metadata
+  postUrl           String   @map("post_url")
+  location          String?
+  publishedAt       DateTime? @map("published_at")
+
+  // Extras (platform-specific data as JSON)
+  platformMeta      Json?    @map("platform_meta") // Flexible for platform-specific fields
+
+  // Usage tracking
+  usageCount        Int      @default(0) @map("usage_count")
+  qualityScore      Float?   @map("quality_score") // LLM-assessed quality (0-1)
+
+  createdAt         DateTime @default(now()) @map("created_at")
+  updatedAt         DateTime @updatedAt @map("updated_at")
+
+  @@unique([platform, platformPostId])  // Prevent duplicates
+  @@index([platform])
+  @@index([query])
+  @@index([location])
+  @@index([engagementScore])
+  @@index([usageCount])
+  @@index([contentLang])                // Filter by language
+  @@map("social_content_cache")
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -21,6 +21,7 @@ import adminRouter from './routes/admin.js';
 import emailRouter from './routes/email.js';
 import emailImportRouter from './routes/emailImport.js';
 import xiaohongshuRouter from './routes/xiaohongshu.js';
+import contentRouter from './routes/content.js';
 import { configurePassport } from './config/passport.js';
 import { logger } from './utils/logger.js';
 import { initializeEmailJobs } from './jobs/emailJobs.js';
@@ -88,7 +89,10 @@ app.use(helmet({
         "https://*.mapbox.com",
         "https://lh3.googleusercontent.com", // Google profile photos
         "https://*.xiaohongshu.com", // Xiaohongshu note images
-        "https://ci.xiaohongshu.com" // Xiaohongshu CDN images
+        "https://ci.xiaohongshu.com", // Xiaohongshu CDN images
+        "https://*.reddit.com", // Reddit images
+        "https://*.redd.it", // Reddit CDN images
+        "https://ui-avatars.com" // Generated avatars
       ],
       fontSrc: [
         "'self'",
@@ -160,7 +164,8 @@ app.use('/api/share', shareRouter); // Public share links (no auth required)
 app.use('/api/subscriptions', subscriptionsRouter);
 app.use('/api/email', emailRouter); // Email preferences and unsubscribe
 app.use('/api/email-import', emailImportRouter); // Email import and parsing (Milestone 5.1)
-app.use('/api/xiaohongshu', xiaohongshuRouter); // Xiaohongshu integration for travel inspiration
+app.use('/api/xiaohongshu', xiaohongshuRouter); // Xiaohongshu integration for travel inspiration (DEPRECATED - use /api/content)
+app.use('/api/content', contentRouter); // Unified content aggregation (Xiaohongshu, Reddit, etc.)
 app.use('/api/admin', adminRouter); // Admin-only endpoints
 
 // Error handling middleware

--- a/server/routes/content.ts
+++ b/server/routes/content.ts
@@ -1,0 +1,202 @@
+/**
+ * Unified Content API
+ * Aggregates content from multiple social platforms (Xiaohongshu, Reddit, etc.)
+ */
+
+import express from 'express';
+import { requireAuth } from '../middleware/auth.js';
+import { aggregateContent } from '../services/content/aggregator.js';
+import { z } from 'zod';
+
+const router = express.Router();
+
+const searchRequestSchema = z.object({
+  destination: z.string().min(1),
+  activityType: z.string().min(1),
+  itemType: z.enum(['sight', 'food', 'museum', 'hike', 'experience', 'transport', 'rest']),
+  language: z.enum(['all', 'en', 'zh', 'ja', 'ko', 'es', 'fr', 'de']).default('all'),
+  platforms: z
+    .array(z.enum(['xiaohongshu', 'reddit', 'tiktok', 'instagram', 'youtube']))
+    .optional(),
+  limit: z.number().min(1).max(20).default(10),
+  defaultDayIndex: z.number().optional(),
+});
+
+/**
+ * POST /api/content/search
+ * Unified endpoint for searching across all platforms
+ *
+ * Request body:
+ * - destination: string (e.g., "Tokyo", "Peru")
+ * - activityType: string (e.g., "food", "hiking", "sightseeing")
+ * - itemType: ItemType enum
+ * - language?: 'all' | 'en' | 'zh' | 'ja' | etc. (default: 'all')
+ * - platforms?: string[] (filter by platforms, e.g., ['reddit', 'xiaohongshu'])
+ * - limit?: number (max results, default 10)
+ * - defaultDayIndex?: number (suggested day index)
+ *
+ * Response:
+ * - suggestions: SuggestionCard[] (ready-to-use suggestion cards)
+ */
+router.post('/search', requireAuth, async (req, res) => {
+  try {
+    const validated = searchRequestSchema.parse(req.body);
+
+    console.log(
+      `[Content API] Searching for ${validated.activityType} in ${validated.destination}` +
+        ` (language: ${validated.language}, platforms: ${validated.platforms?.join(',') || 'all'})`
+    );
+
+    // Aggregate content from all platforms
+    const content = await aggregateContent({
+      query: `${validated.destination} ${validated.activityType}`,
+      destination: validated.destination,
+      activityType: validated.activityType,
+      language: validated.language,
+      platforms: validated.platforms,
+      limit: validated.limit,
+    });
+
+    // Convert to suggestion cards
+    const suggestions = content.map((item) => ({
+      id: `${item.platform}-${item.platformPostId}`,
+      title: item.title,
+      images: item.images,
+      summary: item.summary || item.content.substring(0, 200),
+      quotes: [], // TODO: Extract quotes from content if needed
+      sourceLinks: [
+        {
+          url: item.postUrl,
+          label: `View on ${capitalize(item.platform)}`,
+        },
+      ],
+      itemType: validated.itemType,
+      defaultDayIndex: validated.defaultDayIndex || 0,
+      duration: 'half day',
+      photoQuery: item.title,
+      source: item.platform,
+      platformMeta: {
+        authorName: item.authorName,
+        authorAvatar: item.authorAvatar,
+        likes: item.likes,
+        comments: item.comments,
+        shares: item.shares,
+        platform: item.platform,
+        contentLang: item.contentLang,
+        engagementScore: item.engagementScore,
+        ...item.platformMeta,
+      },
+    }));
+
+    res.json({
+      suggestions,
+      meta: {
+        total: suggestions.length,
+        platforms: [...new Set(content.map((c) => c.platform))],
+        languages: [...new Set(content.map((c) => c.contentLang))],
+      },
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({
+        error: 'Validation error',
+        details: error.errors,
+      });
+    }
+
+    console.error('[Content API] Search error:', error);
+    res.status(500).json({
+      error: 'Search failed',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+/**
+ * GET /api/content/stats
+ * Get statistics about cached content across all platforms
+ */
+router.get('/stats', requireAuth, async (req, res) => {
+  try {
+    const { prisma } = await import('../db.js');
+
+    // Overall stats
+    const totalStats = await prisma.socialContentCache.aggregate({
+      _count: true,
+      _sum: {
+        usageCount: true,
+      },
+      _avg: {
+        engagementScore: true,
+      },
+    });
+
+    // Stats by platform
+    const platformStats = await prisma.socialContentCache.groupBy({
+      by: ['platform'],
+      _count: true,
+      _sum: {
+        usageCount: true,
+      },
+      _avg: {
+        engagementScore: true,
+      },
+    });
+
+    // Stats by language
+    const languageStats = await prisma.socialContentCache.groupBy({
+      by: ['contentLang'],
+      _count: true,
+    });
+
+    // Top content
+    const topContent = await prisma.socialContentCache.findMany({
+      select: {
+        platform: true,
+        title: true,
+        authorName: true,
+        usageCount: true,
+        engagementScore: true,
+        likes: true,
+        comments: true,
+        location: true,
+        contentLang: true,
+      },
+      orderBy: { usageCount: 'desc' },
+      take: 10,
+    });
+
+    res.json({
+      total: {
+        cachedPosts: totalStats._count,
+        totalUsage: totalStats._sum.usageCount || 0,
+        avgEngagement: Math.round(totalStats._avg.engagementScore || 0),
+      },
+      byPlatform: platformStats.map((stat) => ({
+        platform: stat.platform,
+        count: stat._count,
+        usage: stat._sum.usageCount || 0,
+        avgEngagement: Math.round(stat._avg.engagementScore || 0),
+      })),
+      byLanguage: languageStats.map((stat) => ({
+        language: stat.contentLang,
+        count: stat._count,
+      })),
+      topContent,
+    });
+  } catch (error) {
+    console.error('[Content API] Stats error:', error);
+    res.status(500).json({
+      error: 'Failed to get content stats',
+    });
+  }
+});
+
+/**
+ * Helper: Capitalize first letter
+ */
+function capitalize(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+export default router;

--- a/server/services/content/activityExtractor.ts
+++ b/server/services/content/activityExtractor.ts
@@ -1,0 +1,317 @@
+/**
+ * Activity Extractor Service
+ * Extracts specific activities from social media posts and groups them
+ */
+
+import OpenAI from 'openai';
+import type { TravelContent } from './base.js';
+
+// Initialize OpenAI client
+let openai: OpenAI;
+function getOpenAIClient() {
+  if (!openai) {
+    openai = new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+    });
+  }
+  return openai;
+}
+
+export interface ExtractedActivity {
+  activityName: string; // e.g., "Visit Shibuya Crossing"
+  activityType: string; // e.g., "sightseeing", "food", "shopping"
+  description: string; // Short description of what to do
+  detailedDescription?: string; // Longer, more appealing description (1-2 paragraphs)
+  photoKeywords: string; // Keywords for photo search (e.g., "Shibuya Crossing Tokyo Japan nighttime")
+  location?: string; // Specific location if mentioned
+  estimatedDuration?: string; // e.g., "1-2 hours"
+  bestTimeToVisit?: string; // e.g., "evening", "morning"
+  tips?: string; // Any useful tips from the post
+}
+
+export interface Activity {
+  id: string;
+  name: string;
+  type: string;
+  description: string;
+  detailedDescription?: string;
+  photoKeywords: string;
+  location?: string;
+  duration?: string;
+  bestTime?: string;
+  tips: string[];
+  sourcePosts: Array<{
+    platform: string;
+    postUrl: string;
+    authorName: string;
+    authorAvatar?: string;
+    likes: number;
+    comments: number;
+    contentLang: string;
+  }>;
+}
+
+/**
+ * Extract 1-2 specific activities from a social media post
+ */
+export async function extractActivitiesFromPost(
+  content: TravelContent,
+  destination: string
+): Promise<ExtractedActivity[]> {
+  try {
+    const prompt = `You are a travel activity extractor. Extract 1-2 SPECIFIC, ACTIONABLE activities from this ${content.platform} post about ${destination}.
+
+Post Title: ${content.title}
+Post Content: ${content.content}
+
+Requirements:
+1. Extract SPECIFIC activities (e.g., "Visit Shibuya Crossing at night" not "Explore Tokyo")
+2. Include location details if mentioned
+3. Generate good photo search keywords (place name + city + country + descriptive words)
+4. Focus on activities that would interest travelers
+5. Skip generic advice or non-actionable content
+6. Write a detailed, appealing description (1-2 paragraphs) that makes readers excited
+
+Return JSON array of activities:
+[
+  {
+    "activityName": "Visit Shibuya Crossing",
+    "activityType": "sightseeing",
+    "description": "Experience the world's busiest pedestrian crossing with neon lights and crowds",
+    "detailedDescription": "Shibuya Crossing is Tokyo's most iconic intersection and one of the world's busiest pedestrian crossings, with up to 3,000 people crossing at a time during peak hours. The intersection comes alive at night when massive LED screens illuminate the surrounding buildings, creating a cyberpunk atmosphere that defines modern Tokyo. Watch from street level as waves of people surge forward when the lights change, or head to the second-floor Starbucks for a bird's-eye view of the organized chaos below. The crossing represents the perfect blend of Tokyo's efficiency and energy, making it an unmissable experience for first-time visitors.",
+    "photoKeywords": "Shibuya Crossing Tokyo Japan nighttime crowds neon",
+    "location": "Shibuya, Tokyo",
+    "estimatedDuration": "30 minutes",
+    "bestTimeToVisit": "evening",
+    "tips": "Best views from Starbucks overlooking the crossing"
+  }
+]
+
+Return empty array [] if no specific activities found.`;
+
+    const response = await getOpenAIClient().chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        {
+          role: 'system',
+          content: 'You are a travel activity extractor. Extract specific, actionable activities from travel posts. Return valid JSON only.',
+        },
+        { role: 'user', content: prompt },
+      ],
+      temperature: 0.7,
+      max_tokens: 800, // Increased for detailed descriptions
+    });
+
+    const result = response.choices[0]?.message?.content?.trim();
+    if (!result) return [];
+
+    // Strip markdown code fences if present (```json ... ```)
+    const jsonContent = result.replace(/^```json\s*\n?/i, '').replace(/\n?```\s*$/i, '').trim();
+
+    // Parse JSON response
+    const activities = JSON.parse(jsonContent);
+    return Array.isArray(activities) ? activities : [];
+  } catch (error) {
+    console.error(`[ActivityExtractor] Failed to extract activities from ${content.platform} post:`, error);
+    return [];
+  }
+}
+
+/**
+ * Group similar activities from multiple posts
+ */
+export function groupActivities(
+  allActivities: Array<{ activity: ExtractedActivity; post: TravelContent }>
+): Activity[] {
+  const activityGroups = new Map<string, Activity>();
+
+  for (const { activity, post } of allActivities) {
+    // Create a normalized key for grouping (lowercase, remove special chars)
+    const normalizedName = activity.activityName.toLowerCase().replace(/[^\w\s]/g, '');
+
+    // Check if similar activity already exists
+    let groupKey: string | null = null;
+    for (const [key, group] of activityGroups.entries()) {
+      const normalizedGroupName = group.name.toLowerCase().replace(/[^\w\s]/g, '');
+
+      // Simple similarity check: if 60% of words match, consider it the same activity
+      const words1 = normalizedName.split(/\s+/);
+      const words2 = normalizedGroupName.split(/\s+/);
+      const commonWords = words1.filter(w => words2.includes(w)).length;
+      const similarity = commonWords / Math.max(words1.length, words2.length);
+
+      if (similarity > 0.6) {
+        groupKey = key;
+        break;
+      }
+    }
+
+    if (groupKey) {
+      // Add to existing group
+      const group = activityGroups.get(groupKey)!;
+      group.sourcePosts.push({
+        platform: post.platform,
+        postUrl: post.postUrl,
+        authorName: post.authorName,
+        authorAvatar: post.authorAvatar,
+        likes: post.likes,
+        comments: post.comments,
+        contentLang: post.contentLang,
+      });
+
+      // Merge tips
+      if (activity.tips && !group.tips.includes(activity.tips)) {
+        group.tips.push(activity.tips);
+      }
+
+      // Use better description if current one is longer/more detailed
+      if (activity.description.length > group.description.length) {
+        group.description = activity.description;
+      }
+
+      // Use better detailed description if current one is longer
+      if (activity.detailedDescription && (
+        !group.detailedDescription || activity.detailedDescription.length > group.detailedDescription.length
+      )) {
+        group.detailedDescription = activity.detailedDescription;
+      }
+    } else {
+      // Create new group
+      const newActivity: Activity = {
+        id: `activity-${activityGroups.size + 1}`,
+        name: activity.activityName,
+        type: activity.activityType,
+        description: activity.description,
+        photoKeywords: activity.photoKeywords,
+        location: activity.location,
+        duration: activity.estimatedDuration,
+        bestTime: activity.bestTimeToVisit,
+        tips: activity.tips ? [activity.tips] : [],
+        sourcePosts: [{
+          platform: post.platform,
+          postUrl: post.postUrl,
+          authorName: post.authorName,
+          authorAvatar: post.authorAvatar,
+          likes: post.likes,
+          comments: post.comments,
+          contentLang: post.contentLang,
+        }],
+      };
+
+      activityGroups.set(normalizedName, newActivity);
+    }
+  }
+
+  return Array.from(activityGroups.values());
+}
+
+/**
+ * Extract and group activities from multiple posts
+ */
+export async function extractAndGroupActivities(
+  posts: TravelContent[],
+  destination: string,
+  specificLocation?: string,
+  existingActivities?: string[],
+  mainDestination?: string
+): Promise<Activity[]> {
+  console.log(`[ActivityExtractor] Extracting activities from ${posts.length} posts for ${specificLocation || destination}`);
+
+  // Extract activities from all posts in parallel
+  const extractionPromises = posts.map(async (post) => {
+    const activities = await extractActivitiesFromPost(post, destination);
+    return activities.map(activity => ({ activity, post }));
+  });
+
+  const results = await Promise.all(extractionPromises);
+  const allActivities = results.flat();
+
+  console.log(`[ActivityExtractor] Extracted ${allActivities.length} activities from ${posts.length} posts`);
+
+  // STRICT filtering for location relevance and duplicates
+  let filteredActivities = allActivities;
+
+  // Step 1: Filter out activities from completely different countries/destinations
+  if (mainDestination) {
+    const mainDestLower = mainDestination.toLowerCase();
+    const destinationKeywords = mainDestLower.split(/\s+/); // e.g., "Peru" from "Peru"
+
+    filteredActivities = filteredActivities.filter(({ activity }) => {
+      const activityLocation = activity.location?.toLowerCase() || '';
+      const activityName = activity.activityName.toLowerCase();
+      const activityDescription = activity.description.toLowerCase();
+      const allText = `${activityLocation} ${activityName} ${activityDescription}`;
+
+      // Check if the activity mentions the destination country at all
+      const mentionsDestination = destinationKeywords.some(keyword =>
+        keyword.length > 2 && allText.includes(keyword)
+      );
+
+      if (!mentionsDestination) {
+        console.log(`[ActivityExtractor] Filtering out "${activity.activityName}" - doesn't mention ${mainDestination}`);
+        return false;
+      }
+
+      return true;
+    });
+
+    console.log(`[ActivityExtractor] After country filter: ${filteredActivities.length} activities`);
+  }
+
+  // Step 2: Filter by specific location if provided (e.g., "Cusco" when day is in Cusco)
+  if (specificLocation && filteredActivities.length > 0) {
+    const locationLower = specificLocation.toLowerCase();
+    const cityFiltered = filteredActivities.filter(({ activity }) => {
+      const activityLocation = activity.location?.toLowerCase() || '';
+      const activityName = activity.activityName.toLowerCase();
+      const activityDescription = activity.description.toLowerCase();
+
+      return (
+        activityLocation.includes(locationLower) ||
+        activityName.includes(locationLower) ||
+        activityDescription.includes(locationLower)
+      );
+    });
+
+    // Always use city-filtered results when a specific location is provided
+    // Don't fall back to country-wide activities - better to show nothing than wrong city
+    filteredActivities = cityFiltered;
+
+    if (cityFiltered.length > 0) {
+      console.log(`[ActivityExtractor] Filtered to ${filteredActivities.length} activities matching "${specificLocation}"`);
+    } else {
+      console.log(`[ActivityExtractor] No activities match "${specificLocation}" - will return empty`);
+    }
+  }
+
+  // Step 3: Filter out activities already in the itinerary
+  if (existingActivities && existingActivities.length > 0) {
+    const beforeCount = filteredActivities.length;
+    filteredActivities = filteredActivities.filter(({ activity }) => {
+      const activityNameLower = activity.activityName.toLowerCase();
+
+      // Check for exact match or very similar titles
+      const isDuplicate = existingActivities.some(existing => {
+        return (
+          activityNameLower === existing ||
+          activityNameLower.includes(existing) ||
+          existing.includes(activityNameLower)
+        );
+      });
+
+      if (isDuplicate) {
+        console.log(`[ActivityExtractor] Filtering out duplicate: "${activity.activityName}"`);
+      }
+
+      return !isDuplicate;
+    });
+
+    console.log(`[ActivityExtractor] Removed ${beforeCount - filteredActivities.length} duplicates, ${filteredActivities.length} remaining`);
+  }
+
+  // Group similar activities
+  const groupedActivities = groupActivities(filteredActivities);
+  console.log(`[ActivityExtractor] Grouped into ${groupedActivities.length} unique activities`);
+
+  return groupedActivities;
+}

--- a/server/services/content/aggregator.ts
+++ b/server/services/content/aggregator.ts
@@ -1,0 +1,307 @@
+/**
+ * Content Aggregator Service
+ * Aggregates content from multiple platforms (Xiaohongshu, Reddit, etc.)
+ * Handles caching, LLM enhancement, and quality scoring
+ */
+
+import type { ContentProvider, TravelContent, SearchOptions, Platform } from './base.js';
+import { XiaohongshuProvider } from './providers/xiaohongshu.js';
+import { RedditProvider } from './providers/reddit.js';
+import { prisma } from '../../db.js';
+import OpenAI from 'openai';
+
+// Registry of all available providers
+function getEnabledProviders(): ContentProvider[] {
+  const providers: ContentProvider[] = [];
+
+  // Check environment variables for each platform
+  if (process.env.ENABLE_PLATFORM_XIAOHONGSHU === 'true') {
+    providers.push(new XiaohongshuProvider());
+    console.log('[Aggregator] Xiaohongshu provider enabled');
+  }
+
+  if (process.env.ENABLE_PLATFORM_REDDIT === 'true') {
+    providers.push(new RedditProvider());
+    console.log('[Aggregator] Reddit provider enabled');
+  }
+
+  // Future platforms
+  // if (process.env.ENABLE_PLATFORM_TIKTOK === 'true') {
+  //   providers.push(new TikTokProvider());
+  // }
+
+  console.log(`[Aggregator] ${providers.length} provider(s) enabled: ${providers.map(p => p.platform).join(', ')}`);
+  return providers;
+}
+
+const PROVIDERS = getEnabledProviders();
+
+// Initialize OpenAI client
+let openai: OpenAI;
+function getOpenAIClient() {
+  if (!openai) {
+    openai = new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+    });
+  }
+  return openai;
+}
+
+/**
+ * Aggregate content from multiple platforms
+ */
+export async function aggregateContent(options: SearchOptions): Promise<TravelContent[]> {
+  console.log(`[Aggregator] Searching for: "${options.query}"`);
+
+  // 1. Check cache first
+  const cached = await getCachedContent(options);
+  if (cached.length >= (options.limit || 10)) {
+    console.log(`[Aggregator] Using ${cached.length} cached results`);
+    return cached;
+  }
+
+  // 2. Filter providers by platform preference
+  const activeProviders = options.platforms
+    ? PROVIDERS.filter((p) => options.platforms!.includes(p.platform))
+    : PROVIDERS;
+
+  // 3. Fetch from all providers in parallel
+  const results = await Promise.allSettled(
+    activeProviders.map((provider) =>
+      provider.search(options).catch((err) => {
+        console.error(`[${provider.platform}] Search failed:`, err);
+        return [];
+      })
+    )
+  );
+
+  // 4. Flatten and collect all content
+  const allContent: TravelContent[] = [];
+  results.forEach((result) => {
+    if (result.status === 'fulfilled') {
+      allContent.push(...result.value);
+    }
+  });
+
+  if (allContent.length === 0) {
+    console.log('[Aggregator] No content found from any provider');
+    return cached; // Return cached results if any
+  }
+
+  console.log(`[Aggregator] Found ${allContent.length} posts from providers`);
+
+  // 5. Enhance with LLM summaries (parallel, with concurrency limit)
+  const enhanced = await enhanceContentBatch(allContent, options.query);
+
+  // 6. Calculate engagement scores
+  const scored = enhanced.map((content) => {
+    const provider = getProvider(content.platform);
+    return {
+      ...content,
+      engagementScore: provider?.calculateEngagementScore(content) || 0,
+    };
+  });
+
+  // 7. Sort by engagement score
+  scored.sort((a, b) => (b.engagementScore || 0) - (a.engagementScore || 0));
+
+  // 8. Cache results
+  await cacheContentBatch(scored, options.query);
+
+  // 9. Filter by language preference
+  const filtered =
+    options.language && options.language !== 'all'
+      ? scored.filter((c) => c.contentLang === options.language)
+      : scored;
+
+  console.log(`[Aggregator] Returning ${Math.min(filtered.length, options.limit || 10)} results`);
+
+  return filtered.slice(0, options.limit || 10);
+}
+
+/**
+ * Get cached content from database
+ */
+async function getCachedContent(options: SearchOptions): Promise<TravelContent[]> {
+  const thirtyDaysAgo = new Date();
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+  const where: any = {
+    query: { contains: options.destination },
+    createdAt: { gte: thirtyDaysAgo },
+  };
+
+  // Filter by language
+  if (options.language && options.language !== 'all') {
+    where.contentLang = options.language;
+  }
+
+  // Filter by platforms
+  if (options.platforms && options.platforms.length > 0) {
+    where.platform = { in: options.platforms };
+  }
+
+  const cached = await prisma.socialContentCache.findMany({
+    where,
+    orderBy: [{ usageCount: 'desc' }, { engagementScore: 'desc' }],
+    take: options.limit || 10,
+  });
+
+  // Increment usage count for returned results
+  if (cached.length > 0) {
+    await Promise.all(
+      cached.map((item) =>
+        prisma.socialContentCache.update({
+          where: { id: item.id },
+          data: { usageCount: { increment: 1 } },
+        })
+      )
+    );
+  }
+
+  return cached.map(dbContentToTravelContent);
+}
+
+/**
+ * Enhance content with LLM summaries (batch processing)
+ */
+async function enhanceContentBatch(
+  content: TravelContent[],
+  query: string
+): Promise<TravelContent[]> {
+  // Process in batches of 5 to avoid rate limits
+  const batchSize = 5;
+  const enhanced: TravelContent[] = [];
+
+  for (let i = 0; i < content.length; i += batchSize) {
+    const batch = content.slice(i, i + batchSize);
+    const results = await Promise.all(batch.map((item) => enhanceContent(item, query)));
+    enhanced.push(...results);
+  }
+
+  return enhanced;
+}
+
+/**
+ * Enhance single content item with LLM summary
+ */
+async function enhanceContent(content: TravelContent, query: string): Promise<TravelContent> {
+  if (content.summary) return content; // Already summarized
+
+  try {
+    const prompt =
+      content.contentLang === 'zh'
+        ? `Translate and summarize this Chinese travel content in 2-3 concise English sentences highlighting key insights and recommendations:\n\nTitle: ${content.title}\n\nContent: ${content.content}`
+        : `Summarize this travel content in 2-3 concise sentences highlighting key insights and recommendations:\n\nTitle: ${content.title}\n\nContent: ${content.content}`;
+
+    const response = await getOpenAIClient().chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You are a travel content summarizer. Create concise, actionable summaries that help travelers make decisions.',
+        },
+        { role: 'user', content: prompt },
+      ],
+      temperature: 0.7,
+      max_tokens: 150,
+    });
+
+    content.summary =
+      response.choices[0]?.message?.content?.trim() || content.content.substring(0, 200);
+  } catch (error) {
+    console.error('[Aggregator] LLM enhancement failed:', error);
+    // Fallback to truncation
+    content.summary = content.content.substring(0, 200);
+  }
+
+  return content;
+}
+
+/**
+ * Cache content in database (batch upsert)
+ */
+async function cacheContentBatch(content: TravelContent[], query: string): Promise<void> {
+  await Promise.allSettled(
+    content.map(async (item) => {
+      try {
+        await prisma.socialContentCache.upsert({
+          where: {
+            platform_platformPostId: {
+              platform: item.platform,
+              platformPostId: item.platformPostId,
+            },
+          },
+          update: {
+            usageCount: { increment: 1 },
+            summary: item.summary || '',
+            engagementScore: item.engagementScore || 0,
+          },
+          create: {
+            platform: item.platform,
+            platformPostId: item.platformPostId,
+            query,
+            title: item.title,
+            content: item.content,
+            contentLang: item.contentLang,
+            summary: item.summary || '',
+            images: item.images,
+            videoUrl: item.videoUrl,
+            tags: item.tags,
+            authorName: item.authorName,
+            authorId: item.authorId,
+            authorAvatar: item.authorAvatar,
+            engagementScore: item.engagementScore || 0,
+            likes: item.likes,
+            comments: item.comments,
+            shares: item.shares,
+            postUrl: item.postUrl,
+            location: item.location,
+            publishedAt: item.publishedAt,
+            platformMeta: item.platformMeta,
+            usageCount: 1,
+          },
+        });
+      } catch (error) {
+        console.error(`[Aggregator] Failed to cache ${item.platform}/${item.platformPostId}:`, error);
+      }
+    })
+  );
+}
+
+/**
+ * Get provider by platform name
+ */
+function getProvider(platform: Platform): ContentProvider | undefined {
+  return PROVIDERS.find((p) => p.platform === platform);
+}
+
+/**
+ * Convert database record to TravelContent
+ */
+function dbContentToTravelContent(db: any): TravelContent {
+  return {
+    platformPostId: db.platformPostId,
+    platform: db.platform,
+    title: db.title,
+    content: db.content,
+    contentLang: db.contentLang,
+    summary: db.summary,
+    images: db.images,
+    videoUrl: db.videoUrl,
+    tags: db.tags,
+    authorName: db.authorName,
+    authorId: db.authorId,
+    authorAvatar: db.authorAvatar,
+    likes: db.likes,
+    comments: db.comments,
+    shares: db.shares,
+    postUrl: db.postUrl,
+    location: db.location,
+    publishedAt: db.publishedAt,
+    platformMeta: db.platformMeta,
+    engagementScore: db.engagementScore,
+    qualityScore: db.qualityScore,
+  };
+}

--- a/server/services/content/base.ts
+++ b/server/services/content/base.ts
@@ -1,0 +1,69 @@
+/**
+ * Base interfaces for unified content integration across platforms
+ * Supports Xiaohongshu, Reddit, TikTok, Instagram, YouTube, etc.
+ */
+
+export type Platform = 'xiaohongshu' | 'reddit' | 'tiktok' | 'instagram' | 'youtube';
+export type Language = 'en' | 'zh' | 'ja' | 'ko' | 'es' | 'fr' | 'de';
+
+/**
+ * Unified content model for travel-related social posts
+ */
+export interface TravelContent {
+  platformPostId: string;
+  platform: Platform;
+  title: string;
+  content: string;
+  contentLang: Language;
+  summary?: string;
+  images: string[];
+  videoUrl?: string;
+  tags: string[];
+  authorName: string;
+  authorId: string;
+  authorAvatar?: string;
+  likes: number;
+  comments: number;
+  shares: number;
+  postUrl: string;
+  location?: string;
+  publishedAt?: Date;
+  platformMeta?: Record<string, any>;
+  engagementScore?: number;
+  qualityScore?: number;
+}
+
+/**
+ * Search options for finding travel content
+ */
+export interface SearchOptions {
+  query: string;
+  destination: string;
+  activityType: string;
+  language?: 'all' | Language;
+  limit?: number;
+  minEngagement?: number;
+  platforms?: Platform[];
+}
+
+/**
+ * Content provider interface - each platform implements this
+ */
+export interface ContentProvider {
+  platform: Platform;
+
+  /**
+   * Search for content on this platform
+   */
+  search(options: SearchOptions): Promise<TravelContent[]>;
+
+  /**
+   * Normalize engagement metrics to 0-1000 scale
+   */
+  calculateEngagementScore(content: TravelContent): number;
+
+  /**
+   * Platform-specific quality checks
+   */
+  isHighQuality(content: TravelContent): boolean;
+}

--- a/server/services/content/providers/reddit.ts
+++ b/server/services/content/providers/reddit.ts
@@ -1,0 +1,223 @@
+/**
+ * Reddit Content Provider
+ * Uses public JSON API (no authentication required)
+ */
+
+import type { ContentProvider, TravelContent, SearchOptions, Language } from '../base.js';
+
+const TRAVEL_SUBREDDITS = [
+  'travel',
+  'solotravel',
+  'backpacking',
+  'TravelHacks',
+  'JapanTravel',
+  'chinatravel',
+  'digitalnomad',
+  'TravelNoPics',
+  'Shoestring',
+];
+
+export class RedditProvider implements ContentProvider {
+  platform: 'reddit' = 'reddit';
+
+  async search(options: SearchOptions): Promise<TravelContent[]> {
+    try {
+      console.log(`[Reddit] Searching for: "${options.query}"`);
+
+      const posts: TravelContent[] = [];
+
+      // Search across relevant subreddits in parallel
+      const searchPromises = TRAVEL_SUBREDDITS.map((subreddit) =>
+        this.searchSubreddit(subreddit, options.query, options.limit || 3)
+      );
+
+      const results = await Promise.allSettled(searchPromises);
+
+      results.forEach((result) => {
+        if (result.status === 'fulfilled') {
+          posts.push(...result.value);
+        }
+      });
+
+      // Filter high-quality posts only
+      const highQuality = posts.filter((post) => this.isHighQuality(post));
+
+      // Sort by engagement score
+      highQuality.sort((a, b) => {
+        const scoreA = this.calculateEngagementScore(a);
+        const scoreB = this.calculateEngagementScore(b);
+        return scoreB - scoreA;
+      });
+
+      console.log(`[Reddit] Found ${highQuality.length} high-quality posts`);
+
+      return highQuality.slice(0, options.limit || 10);
+    } catch (error) {
+      console.error('[Reddit] Search error:', error);
+      return [];
+    }
+  }
+
+  calculateEngagementScore(content: TravelContent): number {
+    // Reddit: upvotes typically 10-10k range
+    const normalizedUpvotes = Math.min(content.likes / 10, 1000);
+    const normalizedComments = Math.min(content.comments / 5, 1000);
+    const normalizedAwards = Math.min((content.shares || 0) * 100, 1000);
+    return Math.round((normalizedUpvotes + normalizedComments + normalizedAwards) / 3);
+  }
+
+  isHighQuality(content: TravelContent): boolean {
+    // Require minimum upvotes and meaningful content
+    return content.likes >= 50 && content.content.length >= 200;
+  }
+
+  /**
+   * Search a specific subreddit
+   */
+  private async searchSubreddit(
+    subreddit: string,
+    query: string,
+    limit: number
+  ): Promise<TravelContent[]> {
+    try {
+      // Reddit's public JSON API - append .json to any URL
+      const url =
+        `https://www.reddit.com/r/${subreddit}/search.json?` +
+        `q=${encodeURIComponent(query)}&limit=${limit}&sort=relevance&restrict_sr=1`;
+
+      const response = await fetch(url, {
+        headers: {
+          'User-Agent': 'OtterlyGo/1.0 (Travel Planning App)',
+        },
+      });
+
+      if (!response.ok) {
+        console.warn(`[Reddit] Failed to search r/${subreddit}: ${response.status}`);
+        return [];
+      }
+
+      const data = await response.json();
+
+      if (!data?.data?.children) {
+        return [];
+      }
+
+      return data.data.children
+        .filter((child: any) => {
+          const post = child.data;
+          // Filter out:
+          // - Removed/deleted posts
+          // - Short posts (likely not useful)
+          // - Link posts without selftext
+          return (
+            !post.removed_by_category &&
+            post.selftext &&
+            post.selftext.length > 100 &&
+            post.selftext !== '[removed]' &&
+            post.selftext !== '[deleted]'
+          );
+        })
+        .map((child: any) => this.mapRedditPost(child.data, subreddit));
+    } catch (error) {
+      console.error(`[Reddit] Error searching r/${subreddit}:`, error);
+      return [];
+    }
+  }
+
+  /**
+   * Map Reddit post to unified TravelContent
+   */
+  private mapRedditPost(post: any, subreddit: string): TravelContent {
+    return {
+      platformPostId: post.id,
+      platform: 'reddit',
+      title: post.title,
+      content: post.selftext,
+      contentLang: this.detectLanguage(post.selftext),
+      images: this.extractImages(post),
+      tags: this.extractTags(post, subreddit),
+      authorName: post.author,
+      authorId: post.author,
+      likes: post.ups,
+      comments: post.num_comments,
+      shares: post.total_awards_received || 0,
+      postUrl: `https://reddit.com${post.permalink}`,
+      publishedAt: new Date(post.created_utc * 1000),
+      platformMeta: {
+        subreddit: post.subreddit,
+        flair: post.link_flair_text,
+        gilded: post.gilded,
+        upvoteRatio: post.upvote_ratio,
+      },
+    };
+  }
+
+  /**
+   * Detect language from text (simple heuristic)
+   */
+  private detectLanguage(text: string): Language {
+    // Check for Chinese characters
+    const chineseChars = text.match(/[\u4e00-\u9fa5]/g);
+    if (chineseChars && chineseChars.length > text.length * 0.3) {
+      return 'zh';
+    }
+
+    // Check for Japanese characters (Hiragana/Katakana)
+    const japaneseChars = text.match(/[\u3040-\u309f\u30a0-\u30ff]/g);
+    if (japaneseChars && japaneseChars.length > text.length * 0.3) {
+      return 'ja';
+    }
+
+    // Default to English
+    return 'en';
+  }
+
+  /**
+   * Extract images from Reddit post
+   */
+  private extractImages(post: any): string[] {
+    const images: string[] = [];
+
+    // Post thumbnail (if high quality)
+    if (post.thumbnail && post.thumbnail.startsWith('http') && post.thumbnail_width > 140) {
+      images.push(post.thumbnail);
+    }
+
+    // Preview images
+    if (post.preview?.images) {
+      post.preview.images.forEach((img: any) => {
+        if (img.source?.url) {
+          // Reddit uses HTML entities in URLs
+          const url = img.source.url.replace(/&amp;/g, '&');
+          images.push(url);
+        }
+      });
+    }
+
+    // Media (direct image posts)
+    if (post.post_hint === 'image' && post.url) {
+      images.push(post.url);
+    }
+
+    return images;
+  }
+
+  /**
+   * Extract tags from post
+   */
+  private extractTags(post: any, subreddit: string): string[] {
+    const tags: string[] = [subreddit];
+
+    // Add flair as tag
+    if (post.link_flair_text) {
+      tags.push(post.link_flair_text);
+    }
+
+    // Add post hint as tag
+    if (post.post_hint) {
+      tags.push(post.post_hint);
+    }
+
+    return tags;
+  }
+}

--- a/server/services/content/providers/xiaohongshu.ts
+++ b/server/services/content/providers/xiaohongshu.ts
@@ -1,0 +1,229 @@
+/**
+ * Xiaohongshu (小红书) Content Provider
+ * Scrapes public search results and uses fallback sample data
+ */
+
+import type { ContentProvider, TravelContent, SearchOptions } from '../base.js';
+
+// Simplified note structure for web scraping
+interface XiaohongshuNote {
+  note_id: string;
+  title: string;
+  desc: string;
+  user: {
+    user_id: string;
+    nickname: string;
+    avatar?: string;
+  };
+  interact_info: {
+    liked_count: string;
+    comment_count: string;
+  };
+  image_list?: string[];
+  tag_list?: string[];
+  note_url: string;
+  time?: number;
+  location?: string;
+}
+
+export class XiaohongshuProvider implements ContentProvider {
+  platform: 'xiaohongshu' = 'xiaohongshu';
+
+  async search(options: SearchOptions): Promise<TravelContent[]> {
+    try {
+      console.log(`[Xiaohongshu] Searching for: "${options.query}"`);
+
+      const notes = await this.searchNotes(options.query, options.limit);
+
+      return notes.map((note) => this.mapToTravelContent(note));
+    } catch (error) {
+      console.error('[Xiaohongshu] Search error:', error);
+      // Return empty array - aggregator will try other providers
+      return [];
+    }
+  }
+
+  calculateEngagementScore(content: TravelContent): number {
+    // Xiaohongshu typically has 1k-100k likes
+    const normalizedLikes = Math.min(content.likes / 100, 1000);
+    const normalizedComments = Math.min(content.comments / 10, 1000);
+    return Math.round((normalizedLikes + normalizedComments) / 2);
+  }
+
+  isHighQuality(content: TravelContent): boolean {
+    return content.likes >= 1000 && content.comments >= 50;
+  }
+
+  /**
+   * Search Xiaohongshu notes using web scraping
+   * Falls back to sample data if scraping fails
+   */
+  private async searchNotes(query: string, limit = 10): Promise<XiaohongshuNote[]> {
+    try {
+      const searchUrl = `https://www.xiaohongshu.com/search_result?keyword=${encodeURIComponent(query)}`;
+
+      const response = await fetch(searchUrl, {
+        headers: {
+          'User-Agent':
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1',
+          Accept: 'text/html,application/xhtml+xml',
+          'Accept-Language': 'zh-CN,zh;q=0.9',
+        },
+      });
+
+      if (!response.ok) {
+        console.warn('[Xiaohongshu] Search failed, using fallback sample data');
+        return this.getSampleNotes(query);
+      }
+
+      const html = await response.text();
+      const notes = this.parseHTML(html, query);
+
+      if (notes.length === 0) {
+        console.warn('[Xiaohongshu] No notes found, using fallback sample data');
+        return this.getSampleNotes(query);
+      }
+
+      console.log(`[Xiaohongshu] Found ${notes.length} notes`);
+      return notes.slice(0, limit);
+    } catch (error) {
+      console.error('[Xiaohongshu] Fetch error:', error);
+      return this.getSampleNotes(query);
+    }
+  }
+
+  /**
+   * Parse Xiaohongshu HTML (best effort)
+   */
+  private parseHTML(html: string, query: string): XiaohongshuNote[] {
+    try {
+      // Try to extract embedded JSON from script tags
+      const scriptMatch = html.match(
+        /<script>window\.__INITIAL_STATE__\s*=\s*({[\s\S]+?})<\/script>/
+      );
+
+      if (scriptMatch) {
+        const data = JSON.parse(scriptMatch[1]);
+        const notes = data?.note?.noteDetailMap || data?.note?.search?.notes || [];
+
+        return Object.values(notes)
+          .slice(0, 10)
+          .map((note: any) => ({
+            note_id: note.noteId || note.id,
+            title: note.title,
+            desc: note.desc || note.description || '',
+            user: {
+              user_id: note.user?.userId || '',
+              nickname: note.user?.nickname || 'User',
+              avatar: note.user?.avatar,
+            },
+            interact_info: {
+              liked_count: String(note.interactInfo?.likedCount || 0),
+              comment_count: String(note.interactInfo?.commentCount || 0),
+            },
+            image_list: note.imageList?.map((img: any) => img.url) || [],
+            tag_list: note.tagList?.map((tag: any) => tag.name) || [],
+            note_url: `https://www.xiaohongshu.com/explore/${note.noteId || note.id}`,
+            time: note.time,
+            location: note.ipLocation,
+          }));
+      }
+
+      return [];
+    } catch (error) {
+      console.error('[Xiaohongshu] Parse error:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Sample/fallback data for development
+   */
+  private getSampleNotes(query: string): XiaohongshuNote[] {
+    const destination = query.split(' ')[0];
+
+    return [
+      {
+        note_id: `sample-${Date.now()}-1`,
+        title: `${destination}美食探店 | 必吃榜单推荐`,
+        desc: `来${destination}旅游一定不能错过这些地道美食！作为一个资深吃货，我整理了这份超全攻略。从街边小吃到米其林餐厅，每一家都是精心挑选。强烈推荐大家收藏！`,
+        user: {
+          user_id: 'sample-user-1',
+          nickname: '旅行美食家',
+          avatar: 'https://ui-avatars.com/api/?name=Travel+Food',
+        },
+        interact_info: {
+          liked_count: '12580',
+          comment_count: '346',
+        },
+        image_list: [],
+        tag_list: [`${destination}美食`, '旅行攻略', '必吃榜单'],
+        note_url: 'https://www.xiaohongshu.com/explore/sample1',
+        time: Date.now() / 1000,
+        location: destination,
+      },
+      {
+        note_id: `sample-${Date.now()}-2`,
+        title: `${destination}5天4晚完美行程 | 深度游攻略`,
+        desc: `第一次来${destination}的朋友看过来！这条线路我走了3遍，每次都有新发现。分享给大家最优化的行程安排，避开人流高峰，玩转经典景点。记得点赞收藏！`,
+        user: {
+          user_id: 'sample-user-2',
+          nickname: '环球旅行者',
+          avatar: 'https://ui-avatars.com/api/?name=World+Traveler',
+        },
+        interact_info: {
+          liked_count: '8934',
+          comment_count: '221',
+        },
+        image_list: [],
+        tag_list: [`${destination}旅游`, '行程规划', '深度游'],
+        note_url: 'https://www.xiaohongshu.com/explore/sample2',
+        time: Date.now() / 1000,
+        location: destination,
+      },
+      {
+        note_id: `sample-${Date.now()}-3`,
+        title: `${destination}小众景点分享 | 99%的人都不知道`,
+        desc: `厌倦了人山人海的热门景点？这几个小众地方绝对让你惊喜！本地人才知道的秘密花园，拍照超级出片。去过的都说好，赶紧马住！`,
+        user: {
+          user_id: 'sample-user-3',
+          nickname: '旅拍达人',
+          avatar: 'https://ui-avatars.com/api/?name=Photo+Expert',
+        },
+        interact_info: {
+          liked_count: '15240',
+          comment_count: '892',
+        },
+        image_list: [],
+        tag_list: [`${destination}小众`, '旅拍圣地', '网红打卡'],
+        note_url: 'https://www.xiaohongshu.com/explore/sample3',
+        time: Date.now() / 1000,
+        location: destination,
+      },
+    ];
+  }
+
+  /**
+   * Map Xiaohongshu note to unified TravelContent
+   */
+  private mapToTravelContent(note: XiaohongshuNote): TravelContent {
+    return {
+      platformPostId: note.note_id,
+      platform: 'xiaohongshu',
+      title: note.title,
+      content: note.desc,
+      contentLang: 'zh',
+      images: note.image_list || [],
+      tags: note.tag_list || [],
+      authorName: note.user.nickname,
+      authorId: note.user.user_id,
+      authorAvatar: note.user.avatar,
+      likes: parseInt(note.interact_info.liked_count) || 0,
+      comments: parseInt(note.interact_info.comment_count) || 0,
+      shares: 0,
+      postUrl: note.note_url,
+      location: note.location,
+      publishedAt: note.time ? new Date(note.time * 1000) : undefined,
+    };
+  }
+}

--- a/src/components/SuggestionCard.tsx
+++ b/src/components/SuggestionCard.tsx
@@ -66,6 +66,7 @@ export function SuggestionCard({
   );
   const [expandedImage, setExpandedImage] = useState<string | null>(null);
   const [photos, setPhotos] = useState<Photo[]>([]);
+  const [showDetailedDescription, setShowDetailedDescription] = useState(false);
 
   // Use persisted flags from suggestion prop
   const isAdded = suggestion.isAdded ?? false;
@@ -98,41 +99,56 @@ export function SuggestionCard({
 
       {/* Platform Attribution (Xiaohongshu, Reddit, etc.) */}
       {suggestion.source && suggestion.platformMeta && (
-        <div className={getPlatformBgClass(suggestion.source)}>
-          <div className="flex items-center gap-3">
-            {/* Platform Badge */}
-            <PlatformBadge platform={suggestion.source} />
+        <div className="bg-gray-50 border border-gray-200 rounded-lg p-3 mb-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              {/* Show platform badge (Reddit, Xiaohongshu, etc.) or multi-platform badge */}
+              {suggestion.source === 'multi-platform' ? (
+                <div className="bg-blue-500 text-white px-3 py-1 rounded-full text-xs font-medium">
+                  {suggestion.platformMeta.platform || 'Multi-platform'}
+                </div>
+              ) : (
+                <PlatformBadge platform={suggestion.source} />
+              )}
 
-            {/* Language indicator for non-English content */}
-            {suggestion.platformMeta.contentLang && suggestion.platformMeta.contentLang !== 'en' && (
-              <span className="text-xs text-gray-600 bg-white px-2 py-1 rounded-full">
-                {getLanguageLabel(suggestion.platformMeta.contentLang)}
+              {/* Language indicator for non-English content */}
+              {suggestion.platformMeta.contentLang && suggestion.platformMeta.contentLang !== 'en' && (
+                <span className="text-xs text-gray-600 bg-white px-2 py-1 rounded-full border border-gray-200">
+                  {getLanguageLabel(suggestion.platformMeta.contentLang)}
+                </span>
+              )}
+            </div>
+
+            {/* Aggregated engagement metrics */}
+            <div className="flex gap-3 text-xs text-gray-600">
+              <span className="flex items-center gap-1">
+                <span>👍</span>
+                <span className="font-medium">{suggestion.platformMeta.likes?.toLocaleString() || 0}</span>
               </span>
-            )}
-          </div>
-
-          {/* Author Info */}
-          <div className="flex items-center gap-3 mt-2">
-            {suggestion.platformMeta.authorAvatar && (
-              <img
-                src={suggestion.platformMeta.authorAvatar}
-                alt={suggestion.platformMeta.authorName}
-                className="w-8 h-8 rounded-full"
-              />
-            )}
-            <div className="flex-1">
-              <p className="text-sm text-gray-700 font-medium">
-                {suggestion.platformMeta.authorName}
-              </p>
-              <div className="flex gap-3 text-xs text-gray-500 mt-0.5">
-                <span>👍 {suggestion.platformMeta.likes?.toLocaleString() || 0}</span>
-                <span>💬 {suggestion.platformMeta.comments?.toLocaleString() || 0}</span>
-                {suggestion.platformMeta.shares > 0 && (
-                  <span>🏆 {suggestion.platformMeta.shares}</span>
-                )}
-              </div>
+              <span className="flex items-center gap-1">
+                <span>💬</span>
+                <span className="font-medium">{suggestion.platformMeta.comments?.toLocaleString() || 0}</span>
+              </span>
             </div>
           </div>
+
+          {/* Additional metadata (location, best time) */}
+          {(suggestion.platformMeta.location || suggestion.platformMeta.bestTime) && (
+            <div className="flex gap-3 mt-2 text-xs text-gray-600">
+              {suggestion.platformMeta.location && (
+                <span className="flex items-center gap-1">
+                  <span>📍</span>
+                  <span>{suggestion.platformMeta.location}</span>
+                </span>
+              )}
+              {suggestion.platformMeta.bestTime && (
+                <span className="flex items-center gap-1">
+                  <span>⏰</span>
+                  <span>Best time: {suggestion.platformMeta.bestTime}</span>
+                </span>
+              )}
+            </div>
+          )}
         </div>
       )}
 
@@ -230,6 +246,39 @@ export function SuggestionCard({
       {/* Summary */}
       <p className="text-gray-700 mb-4 leading-relaxed">{suggestion.summary}</p>
 
+      {/* Detailed Description (expandable) */}
+      {suggestion.detailedDescription && (
+        <div className="mb-4">
+          {showDetailedDescription && (
+            <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-2">
+              <p className="text-gray-800 leading-relaxed whitespace-pre-line">
+                {suggestion.detailedDescription}
+              </p>
+            </div>
+          )}
+          <button
+            onClick={() => setShowDetailedDescription(!showDetailedDescription)}
+            className="text-sm text-blue-600 hover:text-blue-800 font-medium flex items-center gap-1 transition-colors"
+          >
+            {showDetailedDescription ? (
+              <>
+                <span>Show less</span>
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+                </svg>
+              </>
+            ) : (
+              <>
+                <span>Show more</span>
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </>
+            )}
+          </button>
+        </div>
+      )}
+
       {/* Quotes */}
       {suggestion.quotes.length > 0 && (
         <div className="bg-gray-50 rounded-md p-4 mb-4 space-y-3">
@@ -242,20 +291,47 @@ export function SuggestionCard({
         </div>
       )}
 
-      {/* Source Links */}
+      {/* Source Links - Compact view */}
       {suggestion.sourceLinks.length > 0 && (
-        <div className="flex flex-wrap gap-2 mb-4">
-          {suggestion.sourceLinks.map((link, idx) => (
-            <a
-              key={idx}
-              href={link.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-sm text-blue-600 hover:text-blue-800 underline"
-            >
-              {link.label}
-            </a>
-          ))}
+        <div className="mb-4">
+          <details className="group">
+            <summary className="text-sm text-gray-600 cursor-pointer hover:text-gray-800 flex items-center gap-2 py-2">
+              <span className="text-blue-600">📚</span>
+              <span className="font-medium">
+                Based on {suggestion.sourceLinks.length} {suggestion.sourceLinks.length === 1 ? 'post' : 'posts'}
+              </span>
+              <svg
+                className="w-4 h-4 transition-transform group-open:rotate-180"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </summary>
+            <div className="mt-2 pl-6 space-y-1">
+              {suggestion.sourceLinks.map((link, idx) => (
+                <a
+                  key={idx}
+                  href={link.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm text-blue-600 hover:text-blue-800 hover:bg-blue-50 px-2 py-1 rounded transition-colors flex items-center gap-2 group/link"
+                >
+                  <span className="text-gray-400 group-hover/link:text-blue-600">→</span>
+                  <span className="flex-1 truncate">{link.label}</span>
+                  <svg
+                    className="w-3 h-3 opacity-0 group-hover/link:opacity-100 transition-opacity"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                  </svg>
+                </a>
+              ))}
+            </div>
+          </details>
         </div>
       )}
 

--- a/src/components/SuggestionCard.tsx
+++ b/src/components/SuggestionCard.tsx
@@ -2,6 +2,52 @@ import { useState, useEffect } from 'react';
 import type { SuggestionCard as SuggestionCardType } from '../types';
 import { searchPhotos, type Photo } from '../services/photoApi';
 
+// Platform badge component
+function PlatformBadge({ platform }: { platform: string }) {
+  const badges: Record<string, { bg: string; label: string }> = {
+    xiaohongshu: { bg: 'bg-red-500', label: '小红书' },
+    reddit: { bg: 'bg-orange-500', label: 'Reddit' },
+    tiktok: { bg: 'bg-black', label: 'TikTok' },
+    instagram: { bg: 'bg-pink-500', label: 'Instagram' },
+    youtube: { bg: 'bg-red-600', label: 'YouTube' },
+  };
+
+  const badge = badges[platform] || { bg: 'bg-gray-500', label: platform };
+
+  return (
+    <div className={`${badge.bg} text-white px-3 py-1 rounded-full text-xs font-bold`}>
+      {badge.label}
+    </div>
+  );
+}
+
+// Get platform-specific background class
+function getPlatformBgClass(platform: string): string {
+  const classes: Record<string, string> = {
+    xiaohongshu: 'bg-gradient-to-r from-red-50 to-pink-50 border border-red-200 rounded-md p-3 mb-4',
+    reddit: 'bg-gradient-to-r from-orange-50 to-amber-50 border border-orange-200 rounded-md p-3 mb-4',
+    tiktok: 'bg-gradient-to-r from-gray-50 to-slate-50 border border-gray-200 rounded-md p-3 mb-4',
+    instagram: 'bg-gradient-to-r from-pink-50 to-purple-50 border border-pink-200 rounded-md p-3 mb-4',
+    youtube: 'bg-gradient-to-r from-red-50 to-rose-50 border border-red-200 rounded-md p-3 mb-4',
+  };
+
+  return classes[platform] || 'bg-gradient-to-r from-blue-50 to-indigo-50 border border-blue-200 rounded-md p-3 mb-4';
+}
+
+// Get language label
+function getLanguageLabel(lang: string): string {
+  const labels: Record<string, string> = {
+    zh: '🇨🇳 Chinese',
+    ja: '🇯🇵 Japanese',
+    ko: '🇰🇷 Korean',
+    es: '🇪🇸 Spanish',
+    fr: '🇫🇷 French',
+    de: '🇩🇪 German',
+  };
+
+  return labels[lang] || lang;
+}
+
 interface SuggestionCardProps {
   suggestion: SuggestionCardType;
   onAddToDay: (dayIndex: number) => void;
@@ -50,11 +96,50 @@ export function SuggestionCard({
         {suggestion.title}
       </h3>
 
-      {/* Xiaohongshu Attribution */}
-      {suggestion.source === 'xiaohongshu' && suggestion.xiaohongshuMeta && (
+      {/* Platform Attribution (Xiaohongshu, Reddit, etc.) */}
+      {suggestion.source && suggestion.platformMeta && (
+        <div className={getPlatformBgClass(suggestion.source)}>
+          <div className="flex items-center gap-3">
+            {/* Platform Badge */}
+            <PlatformBadge platform={suggestion.source} />
+
+            {/* Language indicator for non-English content */}
+            {suggestion.platformMeta.contentLang && suggestion.platformMeta.contentLang !== 'en' && (
+              <span className="text-xs text-gray-600 bg-white px-2 py-1 rounded-full">
+                {getLanguageLabel(suggestion.platformMeta.contentLang)}
+              </span>
+            )}
+          </div>
+
+          {/* Author Info */}
+          <div className="flex items-center gap-3 mt-2">
+            {suggestion.platformMeta.authorAvatar && (
+              <img
+                src={suggestion.platformMeta.authorAvatar}
+                alt={suggestion.platformMeta.authorName}
+                className="w-8 h-8 rounded-full"
+              />
+            )}
+            <div className="flex-1">
+              <p className="text-sm text-gray-700 font-medium">
+                {suggestion.platformMeta.authorName}
+              </p>
+              <div className="flex gap-3 text-xs text-gray-500 mt-0.5">
+                <span>👍 {suggestion.platformMeta.likes?.toLocaleString() || 0}</span>
+                <span>💬 {suggestion.platformMeta.comments?.toLocaleString() || 0}</span>
+                {suggestion.platformMeta.shares > 0 && (
+                  <span>🏆 {suggestion.platformMeta.shares}</span>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Legacy Xiaohongshu Attribution (for backward compatibility) */}
+      {suggestion.source === 'xiaohongshu' && suggestion.xiaohongshuMeta && !suggestion.platformMeta && (
         <div className="bg-gradient-to-r from-red-50 to-pink-50 border border-red-200 rounded-md p-3 mb-4">
           <div className="flex items-center gap-3">
-            {/* Xiaohongshu Badge */}
             <div className="flex items-center gap-2">
               <div className="w-6 h-6 bg-red-500 rounded flex items-center justify-center">
                 <span className="text-white text-xs font-bold">小红书</span>
@@ -65,7 +150,6 @@ export function SuggestionCard({
             </div>
           </div>
 
-          {/* Author Info */}
           <div className="flex items-center gap-3 mt-2">
             {suggestion.xiaohongshuMeta.authorAvatar && (
               <img

--- a/src/services/contentApi.ts
+++ b/src/services/contentApi.ts
@@ -1,0 +1,79 @@
+/**
+ * Unified Content API Client
+ * Searches across multiple platforms (Xiaohongshu, Reddit, etc.)
+ */
+
+import type { SuggestionCard, ItemType } from '../types';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+
+export type Platform = 'xiaohongshu' | 'reddit' | 'tiktok' | 'instagram' | 'youtube';
+export type Language = 'all' | 'en' | 'zh' | 'ja' | 'ko' | 'es' | 'fr' | 'de';
+
+export interface ContentSearchRequest {
+  destination: string;
+  activityType: string;
+  itemType: ItemType;
+  language?: Language;
+  platforms?: Platform[];
+  limit?: number;
+  defaultDayIndex?: number;
+}
+
+export interface ContentSearchResponse {
+  suggestions: SuggestionCard[];
+  meta: {
+    total: number;
+    platforms: Platform[];
+    languages: string[];
+  };
+}
+
+/**
+ * Search across all content platforms
+ * Replaces the old searchXiaohongshu() with unified aggregation
+ */
+export async function searchContent(request: ContentSearchRequest): Promise<SuggestionCard[]> {
+  try {
+    const response = await fetch(`${API_URL}/api/content/search`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.message || 'Search failed');
+    }
+
+    const data: ContentSearchResponse = await response.json();
+    return data.suggestions || [];
+  } catch (error) {
+    console.error('[Content API] Search failed:', error);
+    // Return empty array so app continues working
+    return [];
+  }
+}
+
+/**
+ * Get content statistics (admin/debugging)
+ */
+export async function getContentStats() {
+  try {
+    const response = await fetch(`${API_URL}/api/content/stats`, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch content stats');
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error('[Content API] Stats fetch failed:', error);
+    throw error;
+  }
+}

--- a/src/services/conversationEngine.ts
+++ b/src/services/conversationEngine.ts
@@ -118,6 +118,7 @@ class ConversationEngine {
             return {
               message: parsed.content,
               suggestions: parsed.suggestions.map((s: any) => this.enrichSuggestion(s)),
+              quickReplies: parsed.quickReplies, // Preserve quick reply buttons
               usageWarning,
             };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -106,6 +106,7 @@ export interface SuggestionCard {
   title: string;
   images: string[]; // URLs to images
   summary: string; // 2-3 sentence description
+  detailedDescription?: string; // Longer, more appealing description (1-2 paragraphs)
   quotes: Quote[]; // 1-2 quotes
   sourceLinks: SourceLink[]; // 1-3 source links
   defaultDayIndex?: number; // Suggested day to add to (0-based)


### PR DESCRIPTION
## Overview
This PR implements an extensible multi-platform content integration system with **activity-centric extraction**, transforming travel suggestions from post-centric to activity-centric approach.

## Key Features

### 🎯 Activity-Centric Architecture (NEW)
- **LLM Activity Extraction**: Extract 1-2 specific, actionable activities from each social media post
- **Activity Grouping**: 60% word similarity matching to merge similar activities from multiple posts
- **Multi-Source Attribution**: Each activity card shows all source posts that mention it
- **Intelligent Photo Keywords**: LLM-generated descriptive keywords instead of post titles
- **Detailed Descriptions**: Expandable 1-2 paragraph descriptions that are appealing and educational

### 🔍 Intelligent Filtering System (NEW)
- **3-Layer Filtering**:
  1. Country-level: Filter out activities from wrong countries
  2. City-level: Filter to specific city when detected from user request or day context
  3. Duplicate detection: Remove activities already in itinerary
- **Smart Location Detection**: Extract location from user request, day.location, or item.locationHint
- **Strict City Filtering**: Better to show nothing than suggest activities from wrong city

### 🏗️ Platform Architecture
- **Strategy Pattern**: Modular `ContentProvider` interface for easy platform additions
- **Platform Adapters**: Reddit and Xiaohongshu providers with unified interface
- **Content Aggregator**: Centralized service for fetching, enhancing, and caching
- **Database**: Unified `SocialContentCache` table supporting all platforms

### 🌐 Multi-Platform Support
- **Platform Toggles**: Individual on/off switches via environment variables
  - `ENABLE_PLATFORM_XIAOHONGSHU=false`
  - `ENABLE_PLATFORM_REDDIT=true`
- **Reddit Integration**: 9 travel subreddits with quality filtering (50+ upvotes)
- **Xiaohongshu Integration**: Chinese travel content with auto-translation
- **Language Detection**: Auto-detects Chinese/Japanese content
- **Engagement Scoring**: Platform-specific metrics normalized to 0-1000 scale

### 🎨 Frontend Enhancements (NEW)
- **Expandable Descriptions**: "Show more/less" toggle for detailed activity information
- **Improved Card UI**: Better visual hierarchy with gray boxes and blue accents
- **Collapsible Sources**: HTML5 `<details>` element for clean source link display
- **Aggregated Metrics**: Total likes/comments across all source posts
- **Platform Badges**: Clear visual indicators for Reddit, Xiaohongshu, or multi-platform
- **Quick Reply Buttons**: Preserved clickable buttons in suggestion responses

## Files Changed

### Backend - Activity Extraction (NEW)
- `server/services/content/activityExtractor.ts`: LLM-based activity extraction and grouping service
- `server/routes/chat.ts`: Integrated activity extraction with 3-layer filtering

### Backend - Platform Integration
- `prisma/schema.prisma`: Added SocialContentCache model
- `server/services/content/base.ts`: Core types and interfaces
- `server/services/content/providers/xiaohongshu.ts`: Xiaohongshu provider
- `server/services/content/providers/reddit.ts`: Reddit provider
- `server/services/content/aggregator.ts`: Unified aggregation service
- `server/routes/content.ts`: Unified API endpoint
- `server/index.ts`: Added Reddit image CSP headers

### Frontend (NEW)
- `src/components/SuggestionCard.tsx`: 
  - Added expandable detailed descriptions with smooth transitions
  - Improved visual design with better hierarchy
  - Collapsible source links section
  - Fixed quick reply button rendering
- `src/services/conversationEngine.ts`: Preserve quick reply buttons in responses
- `src/types/index.ts`: Added `detailedDescription` field to SuggestionCard
- `src/services/contentApi.ts`: Platform-agnostic API client

### Database
- `prisma/migrations/20251007163953_add_unified_social_content_cache/`: Migration for new table

## Activity-Centric vs Post-Centric

**Before (Post-Centric):**
- 5 posts → 5 cards
- Each card = 1 post summary
- Generic photo keywords from post titles
- No location filtering
- Duplicates possible

**After (Activity-Centric):**
- 10 posts → 5-10 activities → grouped into unique activities
- Each card = 1 specific activity with multiple source links
- LLM-generated photo keywords for better image search
- 3-layer location filtering (country/city/duplicates)
- Detailed descriptions with "Show more/less" toggle
- Smart location detection from context

## Example Transformation

**Old**: "Tokyo Travel Tips [Reddit post]"
**New**: "Visit Shibuya Crossing at Night" (extracted from 3 different posts, with detailed description, location, best time, tips, and 3 source links)

## Testing
✅ Activity extraction from Reddit and Xiaohongshu posts
✅ Activity grouping with 60% word similarity
✅ Country-level filtering (filters out Australia/Japan activities for Peru)
✅ City-level filtering (filters out Lima activities for Cusco)
✅ Duplicate detection (removes activities already in itinerary)
✅ "Show more/less" button for detailed descriptions
✅ Collapsible source links section
✅ Quick reply buttons render as clickable buttons
✅ Platform badges show correctly (single vs multi-platform)
✅ Tested with Peru, Japan, Italy destinations

## Future Extensions
Adding new platforms is now trivial:
1. Create `server/services/content/providers/<platform>.ts`
2. Implement `ContentProvider` interface
3. Add provider to aggregator
4. Add toggle to `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)