### PR TITLE
feat: persist activity details to database

### DIFF
--- a/prisma/migrations/20251008145751_add_activity_details/migration.sql
+++ b/prisma/migrations/20251008145751_add_activity_details/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "activity_details" (
+    "id" TEXT NOT NULL,
+    "trip_id" TEXT NOT NULL,
+    "day_index" INTEGER NOT NULL,
+    "item_id" TEXT NOT NULL,
+    "suggestion_card_json" JSONB NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "activity_details_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "activity_details_trip_id_idx" ON "activity_details"("trip_id");
+
+-- CreateIndex
+CREATE INDEX "activity_details_item_id_idx" ON "activity_details"("item_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "activity_details_trip_id_day_index_item_id_key" ON "activity_details"("trip_id", "day_index", "item_id");
+
+-- AddForeignKey
+ALTER TABLE "activity_details" ADD CONSTRAINT "activity_details_trip_id_fkey" FOREIGN KEY ("trip_id") REFERENCES "trips"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -85,13 +85,14 @@ model Trip {
   updatedAt    DateTime @updatedAt @map("updated_at")
 
   // Relations
-  user          User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  conversations Conversation[]
-  coverPhoto    PhotoLibrary? @relation("TripCoverPhoto", fields: [coverPhotoId], references: [id], onDelete: SetNull)
-  tripPhotos    TripPhoto[]
-  emailLogs     EmailLog[]
-  flightSearches FlightSearch[]
-  flightBookings FlightBooking[]
+  user            User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  conversations   Conversation[]
+  activityDetails ActivityDetails[]
+  coverPhoto      PhotoLibrary?     @relation("TripCoverPhoto", fields: [coverPhotoId], references: [id], onDelete: SetNull)
+  tripPhotos      TripPhoto[]
+  emailLogs       EmailLog[]
+  flightSearches  FlightSearch[]
+  flightBookings  FlightBooking[]
 
   @@index([userId])
   @@index([userId, status]) // Fast filtering by user and status
@@ -100,6 +101,25 @@ model Trip {
   @@index([coverPhotoId])
   @@index([publicShareToken])
   @@map("trips")
+}
+
+// ActivityDetails table - stores persistent activity details/suggestions for itinerary items
+model ActivityDetails {
+  id                  String   @id @default(cuid())
+  tripId              String   @map("trip_id")
+  dayIndex            Int      @map("day_index") // Which day (0-based index)
+  itemId              String   @map("item_id") // Itinerary item ID
+  suggestionCardJson  Json     @map("suggestion_card_json") // Full SuggestionCard data
+  createdAt           DateTime @default(now()) @map("created_at")
+  updatedAt           DateTime @updatedAt @map("updated_at")
+
+  // Relations
+  trip Trip @relation(fields: [tripId], references: [id], onDelete: Cascade)
+
+  @@unique([tripId, dayIndex, itemId]) // One details entry per item
+  @@index([tripId])
+  @@index([itemId])
+  @@map("activity_details")
 }
 
 // Conversations table - stores chat history for trips

--- a/src/components/SuggestionCard.tsx
+++ b/src/components/SuggestionCard.tsx
@@ -73,6 +73,7 @@ export function SuggestionCard({
   // Use persisted flags from suggestion prop
   const isAdded = suggestion.isAdded ?? false;
   const addedToDayIndex = suggestion.addedToDayIndex ?? null;
+  const hideActions = suggestion.hideActions ?? false;
 
   // Fetch photos if photoQuery is provided
   useEffect(() => {
@@ -337,61 +338,63 @@ export function SuggestionCard({
         </div>
       )}
 
-      {/* Actions */}
-      <div className="flex items-center gap-3 pt-4 border-t border-gray-200">
-        {isAdded ? (
-          // Show confirmation message after adding
-          <div className="flex items-center gap-2 text-green-700 font-medium">
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M5 13l4 4L19 7"
-              />
-            </svg>
-            <span>Activity added to Day {addedToDayIndex! + 1}!</span>
-          </div>
-        ) : (
-          // Show action buttons before adding
-          <>
-            <div className="flex items-center gap-2 flex-1">
-              <label htmlFor="day-select" className="text-sm font-medium text-gray-700">
-                Add to:
-              </label>
-              <select
-                id="day-select"
-                value={selectedDayIndex}
-                onChange={(e) => setSelectedDayIndex(Number(e.target.value))}
-                className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+      {/* Actions - Only show if not a details view */}
+      {!hideActions && (
+        <div className="flex items-center gap-3 pt-4 border-t border-gray-200">
+          {isAdded ? (
+            // Show confirmation message after adding
+            <div className="flex items-center gap-2 text-green-700 font-medium">
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
               >
-                {Array.from({ length: maxDays }, (_, i) => (
-                  <option key={i} value={i}>
-                    Day {i + 1}
-                  </option>
-                ))}
-              </select>
-              <button
-                onClick={() => onAddToDay(selectedDayIndex)}
-                className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors font-medium"
-              >
-                Add to Day
-              </button>
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+              <span>Activity added to Day {addedToDayIndex! + 1}!</span>
             </div>
-            <button
-              onClick={onSkip}
-              className="px-4 py-2 text-gray-600 hover:text-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 rounded-md transition-colors"
-            >
-              Skip
-            </button>
-          </>
-        )}
-      </div>
+          ) : (
+            // Show action buttons before adding
+            <>
+              <div className="flex items-center gap-2 flex-1">
+                <label htmlFor="day-select" className="text-sm font-medium text-gray-700">
+                  Add to:
+                </label>
+                <select
+                  id="day-select"
+                  value={selectedDayIndex}
+                  onChange={(e) => setSelectedDayIndex(Number(e.target.value))}
+                  className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  {Array.from({ length: maxDays }, (_, i) => (
+                    <option key={i} value={i}>
+                      Day {i + 1}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  onClick={() => onAddToDay(selectedDayIndex)}
+                  className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors font-medium"
+                >
+                  Add to Day
+                </button>
+              </div>
+              <button
+                onClick={onSkip}
+                className="px-4 py-2 text-gray-600 hover:text-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 rounded-md transition-colors"
+              >
+                Skip
+              </button>
+            </>
+          )}
+        </div>
+      )}
 
       {/* Image Modal */}
       {expandedImage && (

--- a/src/services/activityApi.ts
+++ b/src/services/activityApi.ts
@@ -104,3 +104,103 @@ export async function getActivityDetails(
   const data = await response.json();
   return data.card;
 }
+
+/**
+ * Save activity details to database for persistence
+ */
+export async function saveActivityDetails(
+  tripId: string,
+  dayIndex: number,
+  itemId: string,
+  suggestionCard: SuggestionCard
+): Promise<{ success: boolean; id: string }> {
+  console.log('[activityApi] Saving activity details:', {
+    tripId,
+    dayIndex,
+    itemId,
+    suggestionCardKeys: Object.keys(suggestionCard),
+    suggestionCard,
+  });
+
+  const response = await fetch(`${API_URL}/api/activities/details/save`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+    body: JSON.stringify({
+      tripId,
+      dayIndex,
+      itemId,
+      suggestionCard,
+    }),
+  });
+
+  console.log('[activityApi] Response status:', response.status);
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+    console.error('[activityApi] Failed to save activity details:', error);
+    throw new Error(error.message || error.error || 'Failed to save activity details');
+  }
+
+  const result = await response.json();
+  console.log('[activityApi] Successfully saved activity details:', result);
+  return result;
+}
+
+/**
+ * Get saved activity details from database
+ */
+export async function getActivityDetailsFromDb(
+  tripId: string,
+  dayIndex: number,
+  itemId: string
+): Promise<SuggestionCard | null> {
+  const response = await fetch(
+    `${API_URL}/api/activities/details/${tripId}/${dayIndex}/${itemId}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+    }
+  );
+
+  if (response.status === 404) {
+    return null; // Details don't exist
+  }
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+    throw new Error(error.message || error.error || 'Failed to get activity details');
+  }
+
+  const data = await response.json();
+  return data.card;
+}
+
+/**
+ * Check which items in a trip have saved details
+ * Returns a map of "dayIndex-itemId" -> boolean
+ */
+export async function checkActivityDetails(
+  tripId: string
+): Promise<Record<string, boolean>> {
+  const response = await fetch(`${API_URL}/api/activities/details/${tripId}/check`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+    throw new Error(error.message || error.error || 'Failed to check activity details');
+  }
+
+  const data = await response.json();
+  return data.detailsMap || {};
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -125,6 +125,7 @@ export interface SuggestionCard {
   photoQuery?: string; // LLM-generated photo search query (Milestone 3.3)
   isAdded?: boolean; // Track if this suggestion has been added to itinerary
   addedToDayIndex?: number; // Which day it was added to
+  hideActions?: boolean; // Hide Add/Skip buttons (for details view of already-added items)
   source?: 'xiaohongshu' | 'reddit' | 'multi-platform' | 'ai-generated' | 'generated'; // Source of the suggestion
   xiaohongshuMeta?: XiaohongshuMeta; // Metadata if sourced from Xiaohongshu (deprecated)
   platformMeta?: {


### PR DESCRIPTION
## Summary
- Add database persistence for activity details/suggestions
- Activity details now survive page refreshes
- Details button only appears for items with saved information
- Add/Skip buttons hidden when viewing details from itinerary

## Changes
- **Database**: New `activity_details` table to store suggestion cards
- **Backend**: Three new API endpoints for save/retrieve/check operations
- **Frontend**: Auto-save on add to itinerary and Details click
- **UI**: Conditional rendering of action buttons based on context

## Technical Details
- Migration: `20251008145751_add_activity_details`
- Unique constraint: `tripId + dayIndex + itemId`
- Cascade delete when trip is deleted
- Auth required for save endpoint

## Test Plan
- [x] Add activity to itinerary - Details button appears
- [x] Click Details button - suggestion card displays
- [x] Refresh page - Details button still visible
- [x] View details from itinerary - no Add/Skip buttons
- [x] View suggestion from chat - Add/Skip buttons present

🤖 Generated with [Claude Code](https://claude.com/claude-code)